### PR TITLE
Implement packets for deep client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +37,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -92,7 +104,7 @@ dependencies = [
  "base64ct",
  "blake2",
  "cpufeatures",
- "password-hash",
+ "password-hash 0.5.0",
 ]
 
 [[package]]
@@ -374,6 +386,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +450,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -515,6 +558,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -695,6 +744,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
 name = "deranged"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +808,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +842,7 @@ dependencies = [
  "convert_case",
  "encoding_rs",
  "glob",
- "quick-xml",
+ "quick-xml 0.31.0",
  "rand",
  "serde",
  "thiserror",
@@ -814,9 +881,9 @@ checksum = "63b41cb9dd076076058a4523f009c900c582279536d0b2e45a29aa930e083cc5"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -1009,6 +1076,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1179,26 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
 
 [[package]]
 name = "http"
@@ -1245,12 +1342,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.4",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1406,6 +1524,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "mail-auth"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b0969bac270a60560d3a6f89c812b3e39b2f4b3ca8d866063f482030d14f19"
+dependencies = [
+ "ahash 0.8.3",
+ "flate2",
+ "lru-cache",
+ "mail-builder",
+ "mail-parser",
+ "parking_lot 0.12.1",
+ "quick-xml 0.28.2",
+ "ring 0.16.20",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "trust-dns-resolver",
+ "zip",
+]
+
+[[package]]
+name = "mail-builder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef70f53409852d2612f2249810cbbe0c9931ca25b739b734bafc7f61d88051d4"
+dependencies = [
+ "gethostname",
+]
+
+[[package]]
+name = "mail-parser"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4158a1c18963244e083888b21465846dfb68d6170850ed1ab4742edd57c9d47"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "mail-send"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "735ca5a9c5b6acb5f9e7089ee7b96d10c54d4df91e9b47321ef6bb468f90483d"
+dependencies = [
+ "base64 0.21.4",
+ "gethostname",
+ "mail-auth",
+ "mail-builder",
+ "md5",
+ "rand",
+ "rustls 0.22.2",
+ "rustls-pki-types",
+ "smtp-proto",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "webpki-roots 0.26.1",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1617,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -1455,9 +1653,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
@@ -1575,7 +1773,7 @@ dependencies = [
  "thiserror",
  "time",
  "uuid 1.4.1",
- "zstd",
+ "zstd 0.13.0",
 ]
 
 [[package]]
@@ -1694,6 +1892,17 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
@@ -1708,6 +1917,18 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash 0.4.2",
+ "sha2",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -1945,6 +2166,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2298,8 @@ dependencies = [
  "glob",
  "lazy_static",
  "log",
+ "mail-builder",
+ "mail-send",
  "mysql_async",
  "mysql_common",
  "num-traits",
@@ -2114,6 +2352,16 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.25.2",
  "winreg",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -2229,6 +2477,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -2472,6 +2732,12 @@ name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+
+[[package]]
+name = "smtp-proto"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34344dcc7dd10b3de9224fd68e5f019fff2246d9cdf8e4322f770f48030e0c83"
 
 [[package]]
 name = "socket2"
@@ -2734,6 +3000,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.9",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
@@ -2948,6 +3225,59 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "lazy_static",
+ "rand",
+ "ring 0.16.20",
+ "rustls 0.20.9",
+ "rustls-pemfile 1.0.4",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tracing",
+ "url",
+ "webpki",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "lru-cache",
+ "parking_lot 0.12.1",
+ "resolv-conf",
+ "rustls 0.20.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tracing",
+ "trust-dns-proto",
+ "webpki-roots 0.22.6",
 ]
 
 [[package]]
@@ -3176,6 +3506,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
@@ -3188,6 +3527,12 @@ checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"
@@ -3523,12 +3868,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
 name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 7.0.0",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ rand = "0.8"
 evalexpr = "11.3.0"
 duration-str = "0.7.1"
 version-compare = "0.1"
+mail-send = "0.4.7"
+mail-builder = "0.3.1"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/config/Commands.ron
+++ b/config/Commands.ron
@@ -303,6 +303,25 @@
                     required: false,
                 )
             ]
+        ),
+        (
+            name: "captcha",
+            alias: "c",
+            description: "Show a captcha to a player",
+            usage: "$c noob 1000",
+            admin_level: "Guardian",
+            args: [
+                (
+                    name: "player",
+                    type: "String",
+                    required: true,
+                ),
+                (
+                    name: "experience",
+                    type: "UInt",
+                    required: true,
+                )
+            ]
         )
     ]
 )

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -177,6 +177,9 @@ spike_rate = 12
 # Percentage of max HP that spikes will damage
 spike_damage = 0.2
 
+# Show drops to deep client players when using #item and #npc command
+info_reveals_drops = true
+
 [bard]
 
 # Graphic IDs of weapons that are valid instruments

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -79,6 +79,17 @@ delay_time = 10
 # SMTP settings below must be properly configured
 email_validation = true
 
+# Allow account recovery via email
+# Only works in 0.3.x clients
+# SMTP settings below must be properly configured
+recovery = true
+
+# Show email address to the player when recoverying account
+recovery_show_email = true
+
+# Mask the email address shows to the player (e.g r*******k@gmail.com)
+recovery_mask_email = true
+
 [smtp]
 
 from_name = ""

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -222,6 +222,8 @@ door_close_rate = 3
 # Should be between 12 and 14
 max_name_length = 12
 
+max_title_length = 32
+
 # Should leave at 6 if you want to support the v28 client
 #
 # Setting this will allow deep client players to create characters up to

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -216,7 +216,17 @@ door_close_rate = 3
 
 [character]
 
+# Should be between 12 and 14
+max_name_length = 12
+
+# Should leave at 6 if you want to support the v28 client
+#
+# Setting this will allow deep client players to create characters up to
+# and including the max skin.
+max_skin = 11
+
 max_hair_style = 20
+
 max_hair_color = 9
 
 [npcs]

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -67,6 +67,32 @@ server_name = "Untitled Server"
 rate = 5
 zone = ""
 
+[account]
+
+# Number of seconds player must wait before account is created
+# Only works in 0.3.x clients
+# Accepted values: 10 - 600
+delay_time = 10
+
+# Require email validation for account creation
+# Only works in 0.3.x clients
+# SMTP settings below must be properly configured
+email_validation = true
+
+[smtp]
+
+from_name = ""
+
+from_address = ""
+
+host = ""
+
+port = 587
+
+username = ""
+
+password = ""
+
 # Initial location and home for new characters
 [new_character]
 spawn_map = 192

--- a/config/Config.toml
+++ b/config/Config.toml
@@ -304,6 +304,8 @@ track_timer = 90
 
 [barber]
 
+base_cost = 0
+
 cost_per_level = 200
 
 [guild]

--- a/config/Emails.ron
+++ b/config/Emails.ron
@@ -1,0 +1,28 @@
+(
+  validation: (
+    subject: "REOSERV Confirmation Code",
+    body: "Hi {name},
+
+Thank you for choosing to play on our game server! Your confirmation code is: {code}.
+
+Please enter this code to continue with account registration.
+
+Best regards,
+
+REOSERV Team"
+  ),
+  recovery: (
+    subject: "REOSERV Account Recovery Code",
+    body: "Hi {name}
+
+We've received a request to recover your account. To proceed, please use the following confirmation code: {code}
+
+Enter this code to initiate the account recovery process and regain access to your account. If you didn't request this, please contact our support team immediately.
+
+If you need any assistance or have any concerns, don't hesitate to reach out.
+
+Best regards,
+
+REOSERV Team"
+  )
+)

--- a/src/character.rs
+++ b/src/character.rs
@@ -46,6 +46,7 @@ mod update;
 pub struct Character {
     pub player_id: Option<i32>,
     pub player: Option<PlayerHandle>,
+    pub is_deep: bool,
     pub id: i32,
     pub account_id: i32,
     pub name: String,

--- a/src/character.rs
+++ b/src/character.rs
@@ -36,6 +36,8 @@ mod spell_state;
 pub use spell_state::SpellState;
 mod spell_target;
 pub use spell_target::SpellTarget;
+mod equip_result;
+pub use equip_result::EquipResult;
 mod to_map_info;
 mod unequip;
 mod update;

--- a/src/character.rs
+++ b/src/character.rs
@@ -109,6 +109,7 @@ pub struct Character {
     pub logged_in_at: Option<DateTime<Utc>>,
     pub spell_state: SpellState,
     pub quests: Vec<QuestProgress>,
+    pub captcha_open: bool,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/character/add_item.rs
+++ b/src/character/add_item.rs
@@ -6,7 +6,7 @@ use crate::{ITEM_DB, QUEST_DB};
 use super::Character;
 
 impl Character {
-    pub fn add_item(&mut self, item_id: i32, amount: i32) {
+    pub fn add_item_no_quest_rules(&mut self, item_id: i32, amount: i32) {
         let existing_item = self.items.iter_mut().find(|item| item.id == item_id);
 
         if let Some(existing_item) = existing_item {
@@ -21,6 +21,10 @@ impl Character {
         if let Some(item) = ITEM_DB.items.get(item_id as usize - 1) {
             self.weight += item.weight * amount;
         }
+    }
+
+    pub fn add_item(&mut self, item_id: i32, amount: i32) {
+        self.add_item_no_quest_rules(item_id, amount);
 
         let total_amount = self.get_item_amount(item_id);
 

--- a/src/character/equip.rs
+++ b/src/character/equip.rs
@@ -8,7 +8,7 @@ use crate::ITEM_DB;
 use super::{Character, EquipResult};
 
 impl Character {
-    pub fn equip(&mut self, is_deep: bool, item_id: i32, sub_loc: i32) -> EquipResult {
+    pub fn equip(&mut self, item_id: i32, sub_loc: i32) -> EquipResult {
         if sub_loc > 1 {
             return EquipResult::Failed;
         }
@@ -73,7 +73,7 @@ impl Character {
             };
 
             if *equipment_slot != 0 {
-                if is_deep {
+                if self.is_deep {
                     result = EquipResult::Swapped(*equipment_slot);
                     *equipment_slot = item_id;
                 } else {

--- a/src/character/equip.rs
+++ b/src/character/equip.rs
@@ -5,26 +5,21 @@ use eolib::protocol::{
 
 use crate::ITEM_DB;
 
-use super::Character;
+use super::{Character, EquipResult};
 
 impl Character {
-    pub fn equip(&mut self, item_id: i32, sub_loc: i32) -> bool {
+    pub fn equip(&mut self, is_deep: bool, item_id: i32, sub_loc: i32) -> EquipResult {
         if sub_loc > 1 {
-            return false;
+            return EquipResult::Failed;
         }
-
-        let existing_item = match self.items.iter_mut().find(|item| item.id == item_id) {
-            Some(item) => item,
-            None => return false,
-        };
 
         let item_record = match ITEM_DB.items.get(item_id as usize - 1) {
             Some(item) => item,
-            None => return false,
+            None => return EquipResult::Failed,
         };
 
         if item_record.r#type == ItemType::Armor && item_record.spec2 != i32::from(self.gender) {
-            return false;
+            return EquipResult::Failed;
         }
 
         if self.level < item_record.level_requirement
@@ -35,7 +30,7 @@ impl Character {
             || self.adj_constitution < item_record.con_requirement
             || self.adj_charisma < item_record.cha_requirement
         {
-            return false;
+            return EquipResult::Failed;
         }
 
         if item_record.class_requirement != 0 && item_record.class_requirement != self.class {
@@ -49,98 +44,52 @@ impl Character {
                 );
             }
 
-            return false;
+            return EquipResult::Failed;
         }
 
-        match item_record.r#type {
-            ItemType::Weapon => {
-                if self.equipment.weapon != 0 {
-                    return false;
+        let mut result = EquipResult::Equiped;
+
+        {
+            let equipment_slot = match item_record.r#type {
+                ItemType::Weapon => &mut self.equipment.weapon,
+                ItemType::Shield => &mut self.equipment.shield,
+                ItemType::Armor => &mut self.equipment.armor,
+                ItemType::Hat => &mut self.equipment.hat,
+                ItemType::Boots => &mut self.equipment.boots,
+                ItemType::Gloves => &mut self.equipment.gloves,
+                ItemType::Accessory => &mut self.equipment.accessory,
+                ItemType::Belt => &mut self.equipment.belt,
+                ItemType::Necklace => &mut self.equipment.necklace,
+                ItemType::Ring => &mut self.equipment.ring[sub_loc as usize],
+                ItemType::Armlet => &mut self.equipment.armlet[sub_loc as usize],
+                ItemType::Bracer => &mut self.equipment.bracer[sub_loc as usize],
+                _ => {
+                    warn!(
+                        "{} tried to equip an invalid item type: {:?}",
+                        self.name, item_record.r#type
+                    );
+                    return EquipResult::Failed;
                 }
-                self.equipment.weapon = item_id
-            }
-            ItemType::Shield => {
-                if self.equipment.shield != 0 {
-                    return false;
+            };
+
+            if *equipment_slot != 0 {
+                if is_deep {
+                    result = EquipResult::Swapped(*equipment_slot);
+                    *equipment_slot = item_id;
+                } else {
+                    return EquipResult::Failed;
                 }
-                self.equipment.shield = item_id
-            }
-            ItemType::Armor => {
-                if self.equipment.armor != 0 {
-                    return false;
-                }
-                self.equipment.armor = item_id
-            }
-            ItemType::Hat => {
-                if self.equipment.hat != 0 {
-                    return false;
-                }
-                self.equipment.hat = item_id
-            }
-            ItemType::Boots => {
-                if self.equipment.boots != 0 {
-                    return false;
-                }
-                self.equipment.boots = item_id
-            }
-            ItemType::Gloves => {
-                if self.equipment.gloves != 0 {
-                    return false;
-                }
-                self.equipment.gloves = item_id
-            }
-            ItemType::Accessory => {
-                if self.equipment.accessory != 0 {
-                    return false;
-                }
-                self.equipment.accessory = item_id
-            }
-            ItemType::Belt => {
-                if self.equipment.belt != 0 {
-                    return false;
-                }
-                self.equipment.belt = item_id
-            }
-            ItemType::Necklace => {
-                if self.equipment.necklace != 0 {
-                    return false;
-                }
-                self.equipment.necklace = item_id
-            }
-            ItemType::Ring => {
-                if self.equipment.ring[sub_loc as usize] != 0 {
-                    return false;
-                }
-                self.equipment.ring[sub_loc as usize] = item_id
-            }
-            ItemType::Armlet => {
-                if self.equipment.armlet[sub_loc as usize] != 0 {
-                    return false;
-                }
-                self.equipment.armlet[sub_loc as usize] = item_id
-            }
-            ItemType::Bracer => {
-                if self.equipment.bracer[sub_loc as usize] != 0 {
-                    return false;
-                }
-                self.equipment.bracer[sub_loc as usize] = item_id
-            }
-            _ => {
-                warn!(
-                    "{} tried to equip an invalid item type: {:?}",
-                    self.name, item_record.r#type
-                );
-                return false;
             }
         }
 
-        if existing_item.amount <= 1 {
-            self.items.retain(|item| item.id != item_id);
-        } else {
-            existing_item.amount -= 1;
+        if let EquipResult::Swapped(item_id) = result {
+            self.add_item_no_quest_rules(item_id, 1);
         }
+
+        self.remove_item_no_quest_rules(item_id, 1);
 
         self.calculate_stats();
-        true
+
+        result
     }
 }

--- a/src/character/equip.rs
+++ b/src/character/equip.rs
@@ -79,6 +79,8 @@ impl Character {
                 } else {
                     return EquipResult::Failed;
                 }
+            } else {
+                *equipment_slot = item_id;
             }
         }
 

--- a/src/character/equip_result.rs
+++ b/src/character/equip_result.rs
@@ -1,0 +1,6 @@
+#[derive(PartialEq, Eq)]
+pub enum EquipResult {
+    Failed,
+    Equiped,
+    Swapped(i32),
+}

--- a/src/character/remove_item.rs
+++ b/src/character/remove_item.rs
@@ -5,7 +5,7 @@ use crate::{ITEM_DB, QUEST_DB};
 use super::Character;
 
 impl Character {
-    pub fn remove_item(&mut self, item_id: i32, amount: i32) {
+    pub fn remove_item_no_quest_rules(&mut self, item_id: i32, amount: i32) {
         let existing_item = match self.items.iter_mut().find(|item| item.id == item_id) {
             Some(item) => item,
             None => return,
@@ -20,6 +20,10 @@ impl Character {
         if let Some(item) = ITEM_DB.items.get(item_id as usize - 1) {
             self.weight -= item.weight * amount;
         }
+    }
+
+    pub fn remove_item(&mut self, item_id: i32, amount: i32) {
+        self.remove_item_no_quest_rules(item_id, amount);
 
         let total_amount = self.get_item_amount(item_id);
 

--- a/src/deep/account_accept_client_packet.rs
+++ b/src/deep/account_accept_client_packet.rs
@@ -19,9 +19,9 @@ impl EoSerialize for AccountAcceptClientPacket {
         reader.set_chunked_reading_mode(true);
         let mut packet = Self::new();
         packet.sequence_number = reader.get_short()?;
-        reader.next_chunk();
+        reader.next_chunk()?;
         packet.account_name = reader.get_string()?;
-        reader.next_chunk();
+        reader.next_chunk()?;
         packet.email_address = reader.get_string()?;
         reader.set_chunked_reading_mode(current_chunked_reading_mode);
         Ok(packet)

--- a/src/deep/account_accept_client_packet.rs
+++ b/src/deep/account_accept_client_packet.rs
@@ -7,17 +7,11 @@ pub struct AccountAcceptClientPacket {
     pub email_address: String,
 }
 
-impl AccountAcceptClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for AccountAcceptClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
         reader.set_chunked_reading_mode(true);
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.sequence_number = reader.get_short()?;
         reader.next_chunk()?;
         packet.account_name = reader.get_string()?;

--- a/src/deep/account_accept_client_packet.rs
+++ b/src/deep/account_accept_client_packet.rs
@@ -1,0 +1,38 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AccountAcceptClientPacket {
+    pub sequence_number: i32,
+    pub account_name: String,
+    pub email_address: String,
+}
+
+impl AccountAcceptClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for AccountAcceptClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+        reader.set_chunked_reading_mode(true);
+        let mut packet = Self::new();
+        packet.sequence_number = reader.get_short()?;
+        reader.next_chunk();
+        packet.account_name = reader.get_string()?;
+        reader.next_chunk();
+        packet.email_address = reader.get_string()?;
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.sequence_number)?;
+        writer.add_byte(0xff);
+        writer.add_string(&self.account_name);
+        writer.add_byte(0xff);
+        writer.add_string(&self.email_address);
+        Ok(())
+    }
+}

--- a/src/deep/account_accept_server_packet.rs
+++ b/src/deep/account_accept_server_packet.rs
@@ -7,15 +7,9 @@ pub struct AccountAcceptServerPacket {
     pub reply_code: AccountValidationReply,
 }
 
-impl AccountAcceptServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for AccountAcceptServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.reply_code = AccountValidationReply::from(reader.get_short()?);
         Ok(packet)
     }

--- a/src/deep/account_accept_server_packet.rs
+++ b/src/deep/account_accept_server_packet.rs
@@ -1,0 +1,27 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::AccountValidationReply;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AccountAcceptServerPacket {
+    pub reply_code: AccountValidationReply,
+}
+
+impl AccountAcceptServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for AccountAcceptServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.reply_code = AccountValidationReply::from(reader.get_short()?);
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.reply_code.into())?;
+        Ok(())
+    }
+}

--- a/src/deep/account_config_server_packet.rs
+++ b/src/deep/account_config_server_packet.rs
@@ -1,0 +1,28 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AccountConfigServerPacket {
+    pub delay_time: i32,
+    pub email_validation: bool,
+}
+
+impl AccountConfigServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for AccountConfigServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.delay_time = reader.get_short()?;
+        packet.email_validation = reader.get_char()? == 1;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.delay_time)?;
+        writer.add_char(if self.email_validation { 1 } else { 0 })?;
+        Ok(())
+    }
+}

--- a/src/deep/account_config_server_packet.rs
+++ b/src/deep/account_config_server_packet.rs
@@ -6,15 +6,9 @@ pub struct AccountConfigServerPacket {
     pub email_validation: bool,
 }
 
-impl AccountConfigServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for AccountConfigServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.delay_time = reader.get_short()?;
         packet.email_validation = reader.get_char()? == 1;
         Ok(packet)

--- a/src/deep/account_recover_pin_reply.rs
+++ b/src/deep/account_recover_pin_reply.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum AccountRecoverPinReply {
+    WrongPin,
+    OK,
+    Unrecognized(i32),
+}
+
+impl From<i32> for AccountRecoverPinReply {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::WrongPin,
+            1 => Self::OK,
+            _ => Self::Unrecognized(value),
+        }
+    }
+}
+
+impl From<AccountRecoverPinReply> for i32 {
+    fn from(value: AccountRecoverPinReply) -> i32 {
+        match value {
+            AccountRecoverPinReply::WrongPin => 0,
+            AccountRecoverPinReply::OK => 1,
+            AccountRecoverPinReply::Unrecognized(value) => value,
+        }
+    }
+}
+
+impl Default for AccountRecoverPinReply {
+    fn default() -> Self {
+        Self::WrongPin
+    }
+}

--- a/src/deep/account_recover_reply.rs
+++ b/src/deep/account_recover_reply.rs
@@ -1,0 +1,47 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum AccountRecoverReply {
+    AccountNotFound,
+    RequestAccepted,
+    RequestAcceptedShowEmail,
+    TooManyAttempts,
+    RecoveryDisabled,
+    Busy,
+    TooManyEmails,
+    Unrecognized(i32),
+}
+
+impl From<i32> for AccountRecoverReply {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::AccountNotFound,
+            1 => Self::RequestAccepted,
+            2 => Self::RequestAcceptedShowEmail,
+            3 => Self::TooManyAttempts,
+            4 => Self::RecoveryDisabled,
+            5 => Self::Busy,
+            6 => Self::TooManyEmails,
+            _ => Self::Unrecognized(value),
+        }
+    }
+}
+
+impl From<AccountRecoverReply> for i32 {
+    fn from(value: AccountRecoverReply) -> i32 {
+        match value {
+            AccountRecoverReply::AccountNotFound => 0,
+            AccountRecoverReply::RequestAccepted => 1,
+            AccountRecoverReply::RequestAcceptedShowEmail => 2,
+            AccountRecoverReply::TooManyAttempts => 3,
+            AccountRecoverReply::RecoveryDisabled => 4,
+            AccountRecoverReply::Busy => 5,
+            AccountRecoverReply::TooManyEmails => 6,
+            AccountRecoverReply::Unrecognized(value) => value,
+        }
+    }
+}
+
+impl Default for AccountRecoverReply {
+    fn default() -> Self {
+        Self::AccountNotFound
+    }
+}

--- a/src/deep/account_recover_update_reply.rs
+++ b/src/deep/account_recover_update_reply.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum AccountRecoverUpdateReply {
+    Error,
+    OK,
+    Unrecognized(i32),
+}
+
+impl From<i32> for AccountRecoverUpdateReply {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Error,
+            1 => Self::OK,
+            _ => Self::Unrecognized(value),
+        }
+    }
+}
+
+impl From<AccountRecoverUpdateReply> for i32 {
+    fn from(value: AccountRecoverUpdateReply) -> i32 {
+        match value {
+            AccountRecoverUpdateReply::Error => 0,
+            AccountRecoverUpdateReply::OK => 1,
+            AccountRecoverUpdateReply::Unrecognized(value) => value,
+        }
+    }
+}
+
+impl Default for AccountRecoverUpdateReply {
+    fn default() -> Self {
+        Self::Error
+    }
+}

--- a/src/deep/account_validation_reply.rs
+++ b/src/deep/account_validation_reply.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum AccountValidationReply {
+    Busy,
+    OK,
+    TooManyAttempts,
+    Unrecognized(i32),
+}
+
+impl From<i32> for AccountValidationReply {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => Self::Busy,
+            1 => Self::OK,
+            2 => Self::TooManyAttempts,
+            _ => Self::Unrecognized(value),
+        }
+    }
+}
+
+impl From<AccountValidationReply> for i32 {
+    fn from(value: AccountValidationReply) -> i32 {
+        match value {
+            AccountValidationReply::Busy => 0,
+            AccountValidationReply::OK => 1,
+            AccountValidationReply::TooManyAttempts => 2,
+            AccountValidationReply::Unrecognized(value) => value,
+        }
+    }
+}
+
+impl Default for AccountValidationReply {
+    fn default() -> Self {
+        Self::Busy
+    }
+}

--- a/src/deep/admin_interact_add_server_packet.rs
+++ b/src/deep/admin_interact_add_server_packet.rs
@@ -30,7 +30,7 @@ impl EoSerialize for AdminInteractAddServerPacket {
     }
 
     fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
-        for line in self.lines {
+        for line in &self.lines {
             line.serialize(writer)?;
         }
 

--- a/src/deep/admin_interact_add_server_packet.rs
+++ b/src/deep/admin_interact_add_server_packet.rs
@@ -7,17 +7,11 @@ pub struct AdminInteractAddServerPacket {
     pub lines: Vec<DialogLine>,
 }
 
-impl AdminInteractAddServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for AdminInteractAddServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
 
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         reader.set_chunked_reading_mode(true);
 
         while reader.remaining()? > 0 {

--- a/src/deep/admin_interact_add_server_packet.rs
+++ b/src/deep/admin_interact_add_server_packet.rs
@@ -1,0 +1,39 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::DialogLine;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AdminInteractAddServerPacket {
+    pub lines: Vec<DialogLine>,
+}
+
+impl AdminInteractAddServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for AdminInteractAddServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+
+        let mut packet = Self::new();
+        reader.set_chunked_reading_mode(true);
+
+        while reader.remaining()? > 0 {
+            packet.lines.push(EoSerialize::deserialize(reader)?);
+        }
+
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
+
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        for line in self.lines {
+            line.serialize(writer)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/deep/admin_interact_create_server_packet.rs
+++ b/src/deep/admin_interact_create_server_packet.rs
@@ -8,17 +8,11 @@ pub struct AdminInteractCreateServerPacket {
     pub lines: Vec<DialogLine>,
 }
 
-impl AdminInteractCreateServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for AdminInteractCreateServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
 
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         reader.set_chunked_reading_mode(true);
 
         packet.title = reader.get_string()?;

--- a/src/deep/admin_interact_create_server_packet.rs
+++ b/src/deep/admin_interact_create_server_packet.rs
@@ -37,7 +37,7 @@ impl EoSerialize for AdminInteractCreateServerPacket {
         writer.add_string(&self.title);
         writer.add_byte(0xff);
 
-        for line in self.lines {
+        for line in &self.lines {
             line.serialize(writer)?;
         }
 

--- a/src/deep/admin_interact_create_server_packet.rs
+++ b/src/deep/admin_interact_create_server_packet.rs
@@ -1,0 +1,46 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::DialogLine;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AdminInteractCreateServerPacket {
+    pub title: String,
+    pub lines: Vec<DialogLine>,
+}
+
+impl AdminInteractCreateServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for AdminInteractCreateServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+
+        let mut packet = Self::new();
+        reader.set_chunked_reading_mode(true);
+
+        packet.title = reader.get_string()?;
+        reader.next_chunk()?;
+
+        while reader.remaining()? > 0 {
+            packet.lines.push(EoSerialize::deserialize(reader)?);
+        }
+
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
+
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_string(&self.title);
+        writer.add_byte(0xff);
+
+        for line in self.lines {
+            line.serialize(writer)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/deep/admin_interact_get_client_packet.rs
+++ b/src/deep/admin_interact_get_client_packet.rs
@@ -1,0 +1,28 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::LookupType;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct AdminInteractGetClientPacket {
+    pub lookup_type: LookupType,
+    pub id: i32,
+}
+
+impl AdminInteractGetClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for AdminInteractGetClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.lookup_type = LookupType::from(reader.get_char()?);
+        packet.id = reader.get_short()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        Ok(())
+    }
+}

--- a/src/deep/admin_interact_get_client_packet.rs
+++ b/src/deep/admin_interact_get_client_packet.rs
@@ -8,21 +8,17 @@ pub struct AdminInteractGetClientPacket {
     pub id: i32,
 }
 
-impl AdminInteractGetClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for AdminInteractGetClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.lookup_type = LookupType::from(reader.get_char()?);
         packet.id = reader.get_short()?;
         Ok(packet)
     }
 
     fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_char(self.lookup_type.into())?;
+        writer.add_short(self.id)?;
         Ok(())
     }
 }

--- a/src/deep/admin_interact_take_client_packet.rs
+++ b/src/deep/admin_interact_take_client_packet.rs
@@ -3,12 +3,12 @@ use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWrit
 use super::LookupType;
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
-pub struct AdminInteractGetClientPacket {
+pub struct AdminInteractTakeClientPacket {
     pub lookup_type: LookupType,
     pub id: i32,
 }
 
-impl EoSerialize for AdminInteractGetClientPacket {
+impl EoSerialize for AdminInteractTakeClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let mut packet = Self::default();
         packet.lookup_type = LookupType::from(reader.get_char()?);

--- a/src/deep/boss_ping_server_packet.rs
+++ b/src/deep/boss_ping_server_packet.rs
@@ -1,0 +1,37 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct BossPingServerPacket {
+    pub npc_index: i32,
+    pub npc_id: i32,
+    pub hp: i32,
+    pub hp_percentage: i32,
+    pub killed: bool,
+}
+
+impl BossPingServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for BossPingServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.npc_index = reader.get_short()?;
+        packet.npc_id = reader.get_short()?;
+        packet.hp = reader.get_three()?;
+        packet.hp_percentage = reader.get_char()?;
+        packet.killed = reader.get_char()? == 1;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.npc_index)?;
+        writer.add_short(self.npc_id)?;
+        writer.add_three(self.hp)?;
+        writer.add_char(self.hp_percentage)?;
+        writer.add_char(if self.killed { 1 } else { 0 })?;
+        Ok(())
+    }
+}

--- a/src/deep/boss_ping_server_packet.rs
+++ b/src/deep/boss_ping_server_packet.rs
@@ -9,15 +9,9 @@ pub struct BossPingServerPacket {
     pub killed: bool,
 }
 
-impl BossPingServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for BossPingServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.npc_index = reader.get_short()?;
         packet.npc_id = reader.get_short()?;
         packet.hp = reader.get_three()?;

--- a/src/deep/captcha_agree_server_packet.rs
+++ b/src/deep/captcha_agree_server_packet.rs
@@ -6,15 +6,9 @@ pub struct CaptchaAgreeServerPacket {
     pub captcha: String,
 }
 
-impl CaptchaAgreeServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for CaptchaAgreeServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.id = reader.get_short()?;
         packet.captcha = reader.get_string()?;
         Ok(packet)

--- a/src/deep/captcha_agree_server_packet.rs
+++ b/src/deep/captcha_agree_server_packet.rs
@@ -1,0 +1,28 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct CaptchaAgreeServerPacket {
+    pub id: i32,
+    pub captcha: String,
+}
+
+impl CaptchaAgreeServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for CaptchaAgreeServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.id = reader.get_short()?;
+        packet.captcha = reader.get_string()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.id)?;
+        writer.add_string(&self.captcha);
+        Ok(())
+    }
+}

--- a/src/deep/captcha_close_server_packet.rs
+++ b/src/deep/captcha_close_server_packet.rs
@@ -1,0 +1,25 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct CaptchaCloseServerPacket {
+    pub experience: i32,
+}
+
+impl CaptchaCloseServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for CaptchaCloseServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.experience = reader.get_int()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_int(self.experience)?;
+        Ok(())
+    }
+}

--- a/src/deep/captcha_close_server_packet.rs
+++ b/src/deep/captcha_close_server_packet.rs
@@ -5,15 +5,9 @@ pub struct CaptchaCloseServerPacket {
     pub experience: i32,
 }
 
-impl CaptchaCloseServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for CaptchaCloseServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.experience = reader.get_int()?;
         Ok(packet)
     }

--- a/src/deep/captcha_open_server_packet.rs
+++ b/src/deep/captcha_open_server_packet.rs
@@ -7,15 +7,9 @@ pub struct CaptchaOpenServerPacket {
     pub captcha: Option<String>,
 }
 
-impl CaptchaOpenServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for CaptchaOpenServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.id = reader.get_short()?;
         packet.reward_exp = reader.get_three()?;
         if reader.remaining()? > 0 {

--- a/src/deep/captcha_open_server_packet.rs
+++ b/src/deep/captcha_open_server_packet.rs
@@ -1,0 +1,35 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct CaptchaOpenServerPacket {
+    pub id: i32,
+    pub reward_exp: i32,
+    pub captcha: Option<String>,
+}
+
+impl CaptchaOpenServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for CaptchaOpenServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.id = reader.get_short()?;
+        packet.reward_exp = reader.get_three()?;
+        if reader.remaining()? > 0 {
+            packet.captcha = Some(reader.get_string()?);
+        }
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.id)?;
+        writer.add_three(self.reward_exp)?;
+        if let Some(captcha) = &self.captcha {
+            writer.add_string(captcha);
+        }
+        Ok(())
+    }
+}

--- a/src/deep/captcha_reply_client_packet.rs
+++ b/src/deep/captcha_reply_client_packet.rs
@@ -1,0 +1,28 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct CaptchaReplyClientPacket {
+    pub id: i32,
+    pub captcha: String,
+}
+
+impl CaptchaReplyClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for CaptchaReplyClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.id = reader.get_short()?;
+        packet.captcha = reader.get_string()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.id)?;
+        writer.add_string(&self.captcha);
+        Ok(())
+    }
+}

--- a/src/deep/captcha_reply_client_packet.rs
+++ b/src/deep/captcha_reply_client_packet.rs
@@ -6,15 +6,9 @@ pub struct CaptchaReplyClientPacket {
     pub captcha: String,
 }
 
-impl CaptchaReplyClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for CaptchaReplyClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.id = reader.get_short()?;
         packet.captcha = reader.get_string()?;
         Ok(packet)

--- a/src/deep/captcha_request_client_packet.rs
+++ b/src/deep/captcha_request_client_packet.rs
@@ -5,15 +5,9 @@ pub struct CaptchaRequestClientPacket {
     pub id: i32,
 }
 
-impl CaptchaRequestClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for CaptchaRequestClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.id = reader.get_short()?;
         Ok(packet)
     }

--- a/src/deep/captcha_request_client_packet.rs
+++ b/src/deep/captcha_request_client_packet.rs
@@ -1,0 +1,25 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct CaptchaRequestClientPacket {
+    pub id: i32,
+}
+
+impl CaptchaRequestClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for CaptchaRequestClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.id = reader.get_short()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.id)?;
+        Ok(())
+    }
+}

--- a/src/deep/dialog_line.rs
+++ b/src/deep/dialog_line.rs
@@ -6,26 +6,16 @@ pub struct DialogLine {
     pub right: String,
 }
 
-impl DialogLine {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for DialogLine {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
         reader.set_chunked_reading_mode(true);
-
         let mut dialog = DialogLine::default();
-
         dialog.left = reader.get_string()?;
         reader.next_chunk()?;
         dialog.right = reader.get_string()?;
         reader.next_chunk()?;
-
         reader.set_chunked_reading_mode(current_chunked_reading_mode);
-
         Ok(dialog)
     }
 

--- a/src/deep/dialog_line.rs
+++ b/src/deep/dialog_line.rs
@@ -1,0 +1,39 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct DialogLine {
+    pub left: String,
+    pub right: String,
+}
+
+impl DialogLine {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for DialogLine {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+        reader.set_chunked_reading_mode(true);
+
+        let mut dialog = DialogLine::default();
+
+        dialog.left = reader.get_string()?;
+        reader.next_chunk()?;
+        dialog.right = reader.get_string()?;
+        reader.next_chunk()?;
+
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
+
+        Ok(dialog)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_string(&self.left);
+        writer.add_byte(0xff);
+        writer.add_string(&self.right);
+        writer.add_byte(0xff);
+        Ok(())
+    }
+}

--- a/src/deep/item_report_client_packet.rs
+++ b/src/deep/item_report_client_packet.rs
@@ -6,20 +6,15 @@ pub struct ItemReportClientPacket {
     pub title: String,
 }
 
-impl ItemReportClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for ItemReportClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
         reader.set_chunked_reading_mode(true);
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.item_id = reader.get_short()?;
         reader.next_chunk()?;
         packet.title = reader.get_string()?;
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
         Ok(packet)
     }
 

--- a/src/deep/item_report_client_packet.rs
+++ b/src/deep/item_report_client_packet.rs
@@ -1,0 +1,32 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct ItemReportClientPacket {
+    pub item_id: i32,
+    pub title: String,
+}
+
+impl ItemReportClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for ItemReportClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+        reader.set_chunked_reading_mode(true);
+        let mut packet = Self::new();
+        packet.item_id = reader.get_short()?;
+        reader.next_chunk()?;
+        packet.title = reader.get_string()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.item_id)?;
+        writer.add_byte(0xff);
+        writer.add_string(&self.title);
+        Ok(())
+    }
+}

--- a/src/deep/login_accept_client_packet.rs
+++ b/src/deep/login_accept_client_packet.rs
@@ -5,15 +5,9 @@ pub struct LoginAcceptClientPacket {
     pub pin: String,
 }
 
-impl LoginAcceptClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginAcceptClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.pin = reader.get_string()?;
         Ok(packet)
     }

--- a/src/deep/login_accept_client_packet.rs
+++ b/src/deep/login_accept_client_packet.rs
@@ -1,0 +1,25 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginAcceptClientPacket {
+    pub pin: String,
+}
+
+impl LoginAcceptClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginAcceptClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.pin = reader.get_string()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_string(&self.pin);
+        Ok(())
+    }
+}

--- a/src/deep/login_accept_server_packet.rs
+++ b/src/deep/login_accept_server_packet.rs
@@ -7,15 +7,9 @@ pub struct LoginAcceptServerPacket {
     pub reply_code: AccountRecoverPinReply,
 }
 
-impl LoginAcceptServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginAcceptServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.reply_code = AccountRecoverPinReply::from(reader.get_short()?);
         Ok(packet)
     }

--- a/src/deep/login_accept_server_packet.rs
+++ b/src/deep/login_accept_server_packet.rs
@@ -1,0 +1,27 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::AccountRecoverPinReply;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginAcceptServerPacket {
+    pub reply_code: AccountRecoverPinReply,
+}
+
+impl LoginAcceptServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginAcceptServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.reply_code = AccountRecoverPinReply::from(reader.get_short()?);
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.reply_code.into())?;
+        Ok(())
+    }
+}

--- a/src/deep/login_agree_client_packet.rs
+++ b/src/deep/login_agree_client_packet.rs
@@ -1,0 +1,37 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginAgreeClientPacket {
+    pub account_name: String,
+    pub pin: String,
+    pub password: String,
+}
+
+impl LoginAgreeClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginAgreeClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+        reader.set_chunked_reading_mode(true);
+        let mut packet = Self::new();
+        packet.account_name = reader.get_string()?;
+        reader.next_chunk()?;
+        packet.pin = reader.get_string()?;
+        reader.next_chunk()?;
+        packet.password = reader.get_string()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_string(&self.account_name);
+        writer.add_byte(0xff);
+        writer.add_string(&self.pin);
+        writer.add_byte(0xff);
+        writer.add_string(&self.password);
+        Ok(())
+    }
+}

--- a/src/deep/login_agree_client_packet.rs
+++ b/src/deep/login_agree_client_packet.rs
@@ -7,22 +7,17 @@ pub struct LoginAgreeClientPacket {
     pub password: String,
 }
 
-impl LoginAgreeClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginAgreeClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
         reader.set_chunked_reading_mode(true);
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.account_name = reader.get_string()?;
         reader.next_chunk()?;
         packet.pin = reader.get_string()?;
         reader.next_chunk()?;
         packet.password = reader.get_string()?;
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
         Ok(packet)
     }
 

--- a/src/deep/login_agree_server_packet.rs
+++ b/src/deep/login_agree_server_packet.rs
@@ -7,15 +7,9 @@ pub struct LoginAgreeServerPacket {
     pub reply_code: AccountRecoverUpdateReply,
 }
 
-impl LoginAgreeServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginAgreeServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.reply_code = AccountRecoverUpdateReply::from(reader.get_short()?);
         Ok(packet)
     }

--- a/src/deep/login_agree_server_packet.rs
+++ b/src/deep/login_agree_server_packet.rs
@@ -1,0 +1,27 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::AccountRecoverUpdateReply;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginAgreeServerPacket {
+    pub reply_code: AccountRecoverUpdateReply,
+}
+
+impl LoginAgreeServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginAgreeServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.reply_code = AccountRecoverUpdateReply::from(reader.get_short()?);
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.reply_code.into())?;
+        Ok(())
+    }
+}

--- a/src/deep/login_config_server_packet.rs
+++ b/src/deep/login_config_server_packet.rs
@@ -7,15 +7,9 @@ pub struct LoginConfigServerPacket {
     pub max_character_name: i32,
 }
 
-impl LoginConfigServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginConfigServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.max_skins = reader.get_short()?;
         packet.max_hair_modals = reader.get_short()?;
         packet.max_character_name = reader.get_char()?;

--- a/src/deep/login_config_server_packet.rs
+++ b/src/deep/login_config_server_packet.rs
@@ -1,0 +1,31 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginConfigServerPacket {
+    pub max_skins: i32,
+    pub max_hair_modals: i32,
+    pub max_character_name: i32,
+}
+
+impl LoginConfigServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginConfigServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.max_skins = reader.get_short()?;
+        packet.max_hair_modals = reader.get_short()?;
+        packet.max_character_name = reader.get_char()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.max_skins)?;
+        writer.add_short(self.max_hair_modals)?;
+        writer.add_char(self.max_character_name)?;
+        Ok(())
+    }
+}

--- a/src/deep/login_create_client_packet.rs
+++ b/src/deep/login_create_client_packet.rs
@@ -5,15 +5,9 @@ pub struct LoginCreateClientPacket {
     pub account_name: String,
 }
 
-impl LoginCreateClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginCreateClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.account_name = reader.get_string()?;
         Ok(packet)
     }

--- a/src/deep/login_create_client_packet.rs
+++ b/src/deep/login_create_client_packet.rs
@@ -1,17 +1,17 @@
 use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
-pub struct LoginUseClientPacket {
+pub struct LoginCreateClientPacket {
     pub account_name: String,
 }
 
-impl LoginUseClientPacket {
+impl LoginCreateClientPacket {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl EoSerialize for LoginUseClientPacket {
+impl EoSerialize for LoginCreateClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let mut packet = Self::new();
         packet.account_name = reader.get_string()?;

--- a/src/deep/login_create_server_packet.rs
+++ b/src/deep/login_create_server_packet.rs
@@ -3,18 +3,18 @@ use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWrit
 use super::AccountRecoverReply;
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
-pub struct LoginUseServerPacket {
+pub struct LoginCreateServerPacket {
     pub reply_code: AccountRecoverReply,
     pub email_address: Option<String>,
 }
 
-impl LoginUseServerPacket {
+impl LoginCreateServerPacket {
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl EoSerialize for LoginUseServerPacket {
+impl EoSerialize for LoginCreateServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
         reader.set_chunked_reading_mode(true);

--- a/src/deep/login_create_server_packet.rs
+++ b/src/deep/login_create_server_packet.rs
@@ -8,17 +8,11 @@ pub struct LoginCreateServerPacket {
     pub email_address: Option<String>,
 }
 
-impl LoginCreateServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginCreateServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let current_chunked_reading_mode = reader.get_chunked_reading_mode();
         reader.set_chunked_reading_mode(true);
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.reply_code = AccountRecoverReply::from(reader.get_short()?);
         reader.next_chunk()?;
         if reader.remaining()? > 0 {

--- a/src/deep/login_take_client_packet.rs
+++ b/src/deep/login_take_client_packet.rs
@@ -3,17 +3,10 @@ use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWrit
 #[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct LoginTakeClientPacket;
 
-impl LoginTakeClientPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginTakeClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let packet = Self::new();
         reader.get_byte()?;
-        Ok(packet)
+        Ok(Self::default())
     }
 
     fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {

--- a/src/deep/login_take_client_packet.rs
+++ b/src/deep/login_take_client_packet.rs
@@ -6,7 +6,7 @@ pub struct LoginTakeClientPacket;
 impl EoSerialize for LoginTakeClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         reader.get_byte()?;
-        Ok(Self::default())
+        Ok(Self)
     }
 
     fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {

--- a/src/deep/login_take_client_packet.rs
+++ b/src/deep/login_take_client_packet.rs
@@ -12,7 +12,7 @@ impl LoginTakeClientPacket {
 impl EoSerialize for LoginTakeClientPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let packet = Self::new();
-        reader.get_byte();
+        reader.get_byte()?;
         Ok(packet)
     }
 

--- a/src/deep/login_take_client_packet.rs
+++ b/src/deep/login_take_client_packet.rs
@@ -1,0 +1,23 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginTakeClientPacket;
+
+impl LoginTakeClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginTakeClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let packet = Self::new();
+        reader.get_byte();
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_byte(b'R');
+        Ok(())
+    }
+}

--- a/src/deep/login_take_server_packet.rs
+++ b/src/deep/login_take_server_packet.rs
@@ -1,0 +1,27 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::AccountRecoverReply;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginTakeServerPacket {
+    pub reply_code: AccountRecoverReply,
+}
+
+impl LoginTakeServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginTakeServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.reply_code = AccountRecoverReply::from(reader.get_short()?);
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.reply_code.into())?;
+        Ok(())
+    }
+}

--- a/src/deep/login_take_server_packet.rs
+++ b/src/deep/login_take_server_packet.rs
@@ -7,15 +7,9 @@ pub struct LoginTakeServerPacket {
     pub reply_code: AccountRecoverReply,
 }
 
-impl LoginTakeServerPacket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl EoSerialize for LoginTakeServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
-        let mut packet = Self::new();
+        let mut packet = Self::default();
         packet.reply_code = AccountRecoverReply::from(reader.get_short()?);
         Ok(packet)
     }

--- a/src/deep/login_use_client_packet.rs
+++ b/src/deep/login_use_client_packet.rs
@@ -1,0 +1,25 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginUseClientPacket {
+    pub account_name: String,
+}
+
+impl LoginUseClientPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginUseClientPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.account_name = reader.get_string()?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_string(&self.account_name);
+        Ok(())
+    }
+}

--- a/src/deep/login_use_server_packet.rs
+++ b/src/deep/login_use_server_packet.rs
@@ -20,7 +20,7 @@ impl EoSerialize for LoginUseServerPacket {
         reader.set_chunked_reading_mode(true);
         let mut packet = Self::new();
         packet.reply_code = AccountRecoverReply::from(reader.get_short()?);
-        reader.next_chunk();
+        reader.next_chunk()?;
         if reader.remaining()? > 0 {
             packet.email_address = Some(reader.get_string()?);
         }

--- a/src/deep/login_use_server_packet.rs
+++ b/src/deep/login_use_server_packet.rs
@@ -1,0 +1,39 @@
+use eolib::data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter};
+
+use super::AccountRecoverReply;
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct LoginUseServerPacket {
+    pub reply_code: AccountRecoverReply,
+    pub email_address: Option<String>,
+}
+
+impl LoginUseServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for LoginUseServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let current_chunked_reading_mode = reader.get_chunked_reading_mode();
+        reader.set_chunked_reading_mode(true);
+        let mut packet = Self::new();
+        packet.reply_code = AccountRecoverReply::from(reader.get_short()?);
+        reader.next_chunk();
+        if reader.remaining()? > 0 {
+            packet.email_address = Some(reader.get_string()?);
+        }
+        reader.set_chunked_reading_mode(current_chunked_reading_mode);
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.reply_code.into())?;
+        if let Some(email) = &self.email_address {
+            writer.add_byte(0xff);
+            writer.add_string(email);
+        }
+        Ok(())
+    }
+}

--- a/src/deep/lookup_type.rs
+++ b/src/deep/lookup_type.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub enum LookupType {
+    Item,
+    Npc,
+    Unrecognized(i32),
+}
+
+impl From<i32> for LookupType {
+    fn from(value: i32) -> Self {
+        match value {
+            1 => Self::Item,
+            2 => Self::Npc,
+            _ => Self::Unrecognized(value),
+        }
+    }
+}
+
+impl From<LookupType> for i32 {
+    fn from(value: LookupType) -> i32 {
+        match value {
+            LookupType::Item => 1,
+            LookupType::Npc => 2,
+            LookupType::Unrecognized(value) => value,
+        }
+    }
+}
+
+impl Default for LookupType {
+    fn default() -> Self {
+        Self::Item
+    }
+}

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -77,8 +77,8 @@ pub use login_agree_client_packet::LoginAgreeClientPacket;
 mod login_agree_server_packet;
 pub use login_agree_server_packet::LoginAgreeServerPacket;
 
-mod admin_interact_get_client_packet;
-pub use admin_interact_get_client_packet::AdminInteractGetClientPacket;
+mod admin_interact_take_client_packet;
+pub use admin_interact_take_client_packet::AdminInteractTakeClientPacket;
 
 mod admin_interact_create_server_packet;
 pub use admin_interact_create_server_packet::AdminInteractCreateServerPacket;

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -57,11 +57,11 @@ pub use login_take_client_packet::LoginTakeClientPacket;
 mod login_take_server_packet;
 pub use login_take_server_packet::LoginTakeServerPacket;
 
-mod login_use_client_packet;
-pub use login_use_client_packet::LoginUseClientPacket;
+mod login_create_client_packet;
+pub use login_create_client_packet::LoginCreateClientPacket;
 
-mod login_use_server_packet;
-pub use login_use_server_packet::LoginUseServerPacket;
+mod login_create_server_packet;
+pub use login_create_server_packet::LoginCreateServerPacket;
 
 mod login_accept_client_packet;
 pub use login_accept_client_packet::LoginAcceptClientPacket;

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -1,0 +1,93 @@
+pub const ACTION_SWAP: i32 = 35;
+pub const FAMILY_BOSS: i32 = 52;
+pub const FAMILY_CAPTCHA: i32 = 249;
+pub const ACCOUNT_REPLY_WRONG_PIN: i32 = 8;
+pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
+pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;
+
+mod account_accept_client_packet;
+pub use account_accept_client_packet::AccountAcceptClientPacket;
+
+mod account_accept_server_packet;
+pub use account_accept_server_packet::AccountAcceptServerPacket;
+
+mod account_validation_reply;
+pub use account_validation_reply::AccountValidationReply;
+
+mod account_recover_reply;
+pub use account_recover_reply::AccountRecoverReply;
+
+mod account_recover_pin_reply;
+pub use account_recover_pin_reply::AccountRecoverPinReply;
+
+mod account_recover_update_reply;
+pub use account_recover_update_reply::AccountRecoverUpdateReply;
+
+mod account_config_server_packet;
+pub use account_config_server_packet::AccountConfigServerPacket;
+
+mod boss_ping_server_packet;
+pub use boss_ping_server_packet::BossPingServerPacket;
+
+mod captcha_open_server_packet;
+pub use captcha_open_server_packet::CaptchaOpenServerPacket;
+
+mod captcha_agree_server_packet;
+pub use captcha_agree_server_packet::CaptchaAgreeServerPacket;
+
+mod captcha_close_server_packet;
+pub use captcha_close_server_packet::CaptchaCloseServerPacket;
+
+mod captcha_reply_client_packet;
+pub use captcha_reply_client_packet::CaptchaReplyClientPacket;
+
+mod captcha_request_client_packet;
+pub use captcha_request_client_packet::CaptchaRequestClientPacket;
+
+mod item_report_client_packet;
+pub use item_report_client_packet::ItemReportClientPacket;
+
+mod login_config_server_packet;
+pub use login_config_server_packet::LoginConfigServerPacket;
+
+mod login_take_client_packet;
+pub use login_take_client_packet::LoginTakeClientPacket;
+
+mod login_take_server_packet;
+pub use login_take_server_packet::LoginTakeServerPacket;
+
+mod login_use_client_packet;
+pub use login_use_client_packet::LoginUseClientPacket;
+
+mod login_use_server_packet;
+pub use login_use_server_packet::LoginUseServerPacket;
+
+mod login_accept_client_packet;
+pub use login_accept_client_packet::LoginAcceptClientPacket;
+
+mod login_accept_server_packet;
+pub use login_accept_server_packet::LoginAcceptServerPacket;
+
+mod login_agree_client_packet;
+pub use login_agree_client_packet::LoginAgreeClientPacket;
+
+mod login_agree_server_packet;
+pub use login_agree_server_packet::LoginAgreeServerPacket;
+
+mod admin_interact_get_client_packet;
+pub use admin_interact_get_client_packet::AdminInteractGetClientPacket;
+
+mod admin_interact_create_server_packet;
+pub use admin_interact_create_server_packet::AdminInteractCreateServerPacket;
+
+mod admin_interact_add_server_packet;
+pub use admin_interact_add_server_packet::AdminInteractAddServerPacket;
+
+mod dialog_line;
+pub use dialog_line::DialogLine;
+
+mod lookup_type;
+pub use lookup_type::LookupType;
+
+mod paperdoll_swap_server_packet;
+pub use paperdoll_swap_server_packet::PaperdollSwapServerPacket;

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -3,8 +3,8 @@ pub const ACTION_SWAP: u8 = 35;
 pub const FAMILY_BOSS: u8 = 52;
 // pub const FAMILY_CAPTCHA: u8 = 249;
 pub const ACCOUNT_REPLY_WRONG_PIN: i32 = 8;
-pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
-pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;
+// pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
+// pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;
 
 mod account_accept_client_packet;
 pub use account_accept_client_packet::AccountAcceptClientPacket;

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -1,6 +1,7 @@
-pub const ACTION_SWAP: i32 = 35;
-pub const FAMILY_BOSS: i32 = 52;
-pub const FAMILY_CAPTCHA: i32 = 249;
+pub const ACTION_CONFIG: u8 = 220;
+pub const ACTION_SWAP: u8 = 35;
+pub const FAMILY_BOSS: u8 = 52;
+pub const FAMILY_CAPTCHA: u8 = 249;
 pub const ACCOUNT_REPLY_WRONG_PIN: i32 = 8;
 pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
 pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -1,10 +1,12 @@
+#![allow(unused_imports, dead_code, clippy::field_reassign_with_default)]
+
 pub const ACTION_CONFIG: u8 = 220;
 pub const ACTION_SWAP: u8 = 35;
 pub const FAMILY_BOSS: u8 = 52;
-// pub const FAMILY_CAPTCHA: u8 = 249;
+pub const FAMILY_CAPTCHA: u8 = 249;
 pub const ACCOUNT_REPLY_WRONG_PIN: i32 = 8;
-// pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
-// pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;
+pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
+pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;
 
 mod account_accept_client_packet;
 pub use account_accept_client_packet::AccountAcceptClientPacket;

--- a/src/deep/mod.rs
+++ b/src/deep/mod.rs
@@ -1,7 +1,7 @@
 pub const ACTION_CONFIG: u8 = 220;
 pub const ACTION_SWAP: u8 = 35;
 pub const FAMILY_BOSS: u8 = 52;
-pub const FAMILY_CAPTCHA: u8 = 249;
+// pub const FAMILY_CAPTCHA: u8 = 249;
 pub const ACCOUNT_REPLY_WRONG_PIN: i32 = 8;
 pub const AVATAR_CHANGE_TYPE_SKIN: i32 = 4;
 pub const AVATAR_CHANGE_TYPE_GENDER: i32 = 5;

--- a/src/deep/paperdoll_swap_server_packet.rs
+++ b/src/deep/paperdoll_swap_server_packet.rs
@@ -1,6 +1,6 @@
 use eolib::{
     data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter},
-    protocol::net::server::{AvatarChange, CharacterStatsEquipmentChange, EquipmentChange},
+    protocol::net::server::{AvatarChange, CharacterStatsEquipmentChange},
 };
 
 #[derive(Debug, Default, PartialEq, Eq, Clone)]

--- a/src/deep/paperdoll_swap_server_packet.rs
+++ b/src/deep/paperdoll_swap_server_packet.rs
@@ -1,0 +1,50 @@
+use eolib::{
+    data::{EoReader, EoReaderError, EoSerialize, EoSerializeError, EoWriter},
+    protocol::net::server::{CharacterStatsEquipmentChange, EquipmentChange},
+};
+
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+pub struct PaperdollSwapServerPacket {
+    pub player_id: i32,
+    pub equipment: EquipmentChange,
+    pub equiped_item_id: i32,
+    pub equiped_item_amount: i32,
+    pub removed_item_id: i32,
+    pub removed_item_amount: i32,
+    pub stats: CharacterStatsEquipmentChange,
+}
+
+impl PaperdollSwapServerPacket {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EoSerialize for PaperdollSwapServerPacket {
+    fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
+        let mut packet = Self::new();
+        packet.player_id = reader.get_short()?;
+        reader.get_char();
+        reader.get_char();
+        packet.equipment = EoSerialize::deserialize(reader)?;
+        packet.equiped_item_id = reader.get_short()?;
+        packet.equiped_item_amount = reader.get_three()?;
+        packet.removed_item_id = reader.get_short()?;
+        packet.removed_item_amount = reader.get_three()?;
+        packet.stats = EoSerialize::deserialize(reader)?;
+        Ok(packet)
+    }
+
+    fn serialize(&self, writer: &mut EoWriter) -> Result<(), EoSerializeError> {
+        writer.add_short(self.player_id)?;
+        writer.add_char(1)?;
+        writer.add_char(0)?;
+        self.equipment.serialize(writer)?;
+        writer.add_short(self.equiped_item_id)?;
+        writer.add_three(self.equiped_item_amount)?;
+        writer.add_short(self.removed_item_id)?;
+        writer.add_three(self.removed_item_amount)?;
+        self.stats.serialize(writer)?;
+        Ok(())
+    }
+}

--- a/src/deep/paperdoll_swap_server_packet.rs
+++ b/src/deep/paperdoll_swap_server_packet.rs
@@ -24,8 +24,8 @@ impl EoSerialize for PaperdollSwapServerPacket {
     fn deserialize(reader: &EoReader) -> Result<Self, EoReaderError> {
         let mut packet = Self::new();
         packet.player_id = reader.get_short()?;
-        reader.get_char();
-        reader.get_char();
+        reader.get_char()?;
+        reader.get_char()?;
         packet.equipment = EoSerialize::deserialize(reader)?;
         packet.equiped_item_id = reader.get_short()?;
         packet.equiped_item_amount = reader.get_three()?;

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -1,0 +1,24 @@
+use config::{Config, ConfigError, File};
+
+#[derive(Debug, Deserialize)]
+pub struct EmailTemplate {
+    pub subject: String,
+    pub body: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Emails {
+    pub validation: EmailTemplate,
+    pub recovery: EmailTemplate,
+}
+
+impl Emails {
+    pub fn new() -> Result<Self, ConfigError> {
+        let s = Config::builder()
+            .add_source(File::with_name("config/Emails.ron"))
+            .add_source(File::with_name("config/Emails.local.ron").required(false))
+            .build()?;
+
+        s.try_deserialize()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use lazy_static::lazy_static;
 mod utils;
 mod arenas;
 mod character;
+mod deep;
 use arenas::Arenas;
 mod commands;
 use commands::Commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use commands::Commands;
 mod connection_log;
 mod formulas;
 use formulas::Formulas;
+mod emails;
 mod errors;
 mod lang;
 mod map;
@@ -43,6 +44,7 @@ use tokio::{net::TcpListener, signal, time};
 use world::WorldHandle;
 
 use crate::{
+    emails::Emails,
     lang::Lang,
     player::PlayerHandle,
     utils::{
@@ -59,6 +61,7 @@ lazy_static! {
     static ref COMMANDS: Commands = Commands::new().expect("Failed to load commands!");
     static ref FORMULAS: Formulas = Formulas::new().expect("Failed to load formulas!");
     static ref LANG: Lang = Lang::new().expect("Failed to load lang!");
+    static ref EMAILS: Emails = Emails::new().expect("Failed to load emails!");
     static ref CLASS_DB: Ecf = load_class_file().expect("Failed to load ECF file!");
     static ref DROP_DB: DropFile = load_drop_file().expect("Failed to load Drop file!");
     static ref INN_DB: InnFile = load_inn_file().expect("Failed to load Inn file!");

--- a/src/map/command.rs
+++ b/src/map/command.rs
@@ -67,6 +67,10 @@ pub enum Command {
         player_id: i32,
         target: SpellTarget,
     },
+    CloseCaptcha {
+        player_id: i32,
+        experience: i32,
+    },
     CraftItem {
         player_id: i32,
         npc_index: i32,
@@ -237,6 +241,9 @@ pub enum Command {
     OpenBoard {
         player_id: i32,
         board_id: i32,
+    },
+    OpenCaptcha {
+        player_id: i32,
     },
     OpenChest {
         player_id: i32,

--- a/src/map/command.rs
+++ b/src/map/command.rs
@@ -478,6 +478,11 @@ pub enum Command {
         player_id: i32,
         item_id: i32,
     },
+    UseTitleItem {
+        player_id: i32,
+        item_id: i32,
+        title: String,
+    },
     ViewBoardPost {
         player_id: i32,
         board_id: i32,

--- a/src/map/command.rs
+++ b/src/map/command.rs
@@ -115,6 +115,7 @@ pub enum Command {
     },
     Equip {
         player_id: i32,
+        is_deep: bool,
         item_id: i32,
         sub_loc: i32,
     },

--- a/src/map/command.rs
+++ b/src/map/command.rs
@@ -115,7 +115,6 @@ pub enum Command {
     },
     Equip {
         player_id: i32,
-        is_deep: bool,
         item_id: i32,
         sub_loc: i32,
     },

--- a/src/map/map.rs
+++ b/src/map/map.rs
@@ -655,7 +655,7 @@ impl Map {
                 npc_index,
             } => self.upgrade_locker(player_id, npc_index),
 
-            Command::UseItem { player_id, item_id } => self.use_item(player_id, item_id).await,
+            Command::UseItem { player_id, item_id } => self.use_item(player_id, item_id),
 
             Command::ViewBoardPost {
                 player_id,

--- a/src/map/map.rs
+++ b/src/map/map.rs
@@ -172,6 +172,11 @@ impl Map {
 
             Command::CastSpell { player_id, target } => self.cast_spell(player_id, target).await,
 
+            Command::CloseCaptcha {
+                player_id,
+                experience,
+            } => self.close_captcha(player_id, experience),
+
             Command::CraftItem {
                 player_id,
                 npc_index,
@@ -381,6 +386,8 @@ impl Map {
                 player_id,
                 board_id,
             } => self.open_board(player_id, board_id),
+
+            Command::OpenCaptcha { player_id } => self.open_captcha(player_id),
 
             Command::OpenChest { player_id, coords } => self.open_chest(player_id, coords),
 

--- a/src/map/map.rs
+++ b/src/map/map.rs
@@ -234,10 +234,9 @@ impl Map {
 
             Command::Equip {
                 player_id,
-                is_deep,
                 item_id,
                 sub_loc,
-            } => self.equip(player_id, is_deep, item_id, sub_loc),
+            } => self.equip(player_id, item_id, sub_loc),
 
             Command::Face {
                 player_id: target_player_id,

--- a/src/map/map.rs
+++ b/src/map/map.rs
@@ -657,6 +657,12 @@ impl Map {
 
             Command::UseItem { player_id, item_id } => self.use_item(player_id, item_id),
 
+            Command::UseTitleItem {
+                player_id,
+                item_id,
+                title,
+            } => self.use_title_item(player_id, item_id, title),
+
             Command::ViewBoardPost {
                 player_id,
                 board_id,

--- a/src/map/map.rs
+++ b/src/map/map.rs
@@ -234,9 +234,10 @@ impl Map {
 
             Command::Equip {
                 player_id,
+                is_deep,
                 item_id,
                 sub_loc,
-            } => self.equip(player_id, item_id, sub_loc).await,
+            } => self.equip(player_id, is_deep, item_id, sub_loc),
 
             Command::Face {
                 player_id: target_player_id,

--- a/src/map/map/barber/buy_haircut.rs
+++ b/src/map/map/barber/buy_haircut.rs
@@ -50,7 +50,8 @@ impl Map {
             return;
         }
 
-        let cost = cmp::max(1, character.level) * SETTINGS.barber.cost_per_level;
+        let cost = SETTINGS.barber.base_cost
+            + cmp::max(1, character.level) * SETTINGS.barber.cost_per_level;
 
         if character.get_item_amount(1) < cost {
             return;

--- a/src/map/map/character/attack.rs
+++ b/src/map/map/character/attack.rs
@@ -178,11 +178,10 @@ impl Map {
 
             let protected = npc_data.behavior_id == 0
                 && !npc.opponents.is_empty()
-                && !npc.opponents.iter().any(|o| {
-                    o.player_id == player_id
-                        || party_player_ids.contains(&o.player_id)
-                        || o.bored_ticks >= SETTINGS.npcs.bored_timer
-                });
+                && !npc
+                    .opponents
+                    .iter()
+                    .any(|o| o.player_id == player_id || party_player_ids.contains(&o.player_id));
 
             let damage_dealt = if protected {
                 0

--- a/src/map/map/character/attack.rs
+++ b/src/map/map/character/attack.rs
@@ -358,6 +358,10 @@ impl Map {
             None => return,
         };
 
+        if target_character.hidden || target_character.captcha_open {
+            return;
+        }
+
         let amount = {
             let mut rng = rand::thread_rng();
             rng.gen_range(min_damage..=max_damage)

--- a/src/map/map/character/cast_spell.rs
+++ b/src/map/map/character/cast_spell.rs
@@ -16,7 +16,7 @@ use rand::Rng;
 use crate::utils::in_client_range;
 use crate::{
     character::{SpellState, SpellTarget},
-    NPC_DB, SETTINGS, SPELL_DB,
+    NPC_DB, SPELL_DB,
 };
 
 use super::super::Map;
@@ -389,11 +389,10 @@ impl Map {
 
         let protected = npc_data.behavior_id == 0
             && !npc.opponents.is_empty()
-            && !npc.opponents.iter().any(|o| {
-                o.player_id == player_id
-                    || party_player_ids.contains(&o.player_id)
-                    || o.bored_ticks >= SETTINGS.npcs.bored_timer
-            });
+            && !npc
+                .opponents
+                .iter()
+                .any(|o| o.player_id == player_id || party_player_ids.contains(&o.player_id));
 
         let damage_dealt = if protected {
             0

--- a/src/map/map/character/cast_spell.rs
+++ b/src/map/map/character/cast_spell.rs
@@ -471,6 +471,10 @@ impl Map {
                 None => return,
             };
 
+            if target_character.hidden || target_character.captcha_open {
+                return;
+            }
+
             let critical = target_character.hp == target_character.max_hp;
 
             target_character.damage(amount, accuracy, critical)

--- a/src/map/map/character/close_captcha.rs
+++ b/src/map/map/character/close_captcha.rs
@@ -1,0 +1,46 @@
+use eolib::protocol::net::{server::RecoverReplyServerPacket, PacketAction, PacketFamily};
+
+use crate::deep::{CaptchaCloseServerPacket, FAMILY_CAPTCHA};
+
+use super::super::Map;
+
+impl Map {
+    pub fn close_captcha(&mut self, player_id: i32, experience: i32) {
+        let character = match self.characters.get_mut(&player_id) {
+            Some(character) => character,
+            None => return,
+        };
+
+        if !character.is_deep {
+            return;
+        }
+
+        let leveled_up = character.add_experience(experience);
+
+        if let Some(player) = &character.player {
+            player.send(
+                PacketAction::Close,
+                PacketFamily::Unrecognized(FAMILY_CAPTCHA),
+                &CaptchaCloseServerPacket {
+                    experience: character.experience,
+                },
+            );
+
+            if leveled_up {
+                player.send(
+                    PacketAction::Reply,
+                    PacketFamily::Recover,
+                    &RecoverReplyServerPacket {
+                        experience,
+                        karma: character.karma,
+                        level_up: Some(character.level),
+                        stat_points: Some(character.stat_points),
+                        skill_points: Some(character.skill_points),
+                    },
+                )
+            }
+        }
+
+        character.captcha_open = false;
+    }
+}

--- a/src/map/map/character/equip.rs
+++ b/src/map/map/character/equip.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::super::Map;
 
 impl Map {
-    pub fn equip(&mut self, player_id: i32, is_deep: bool, item_id: i32, sub_loc: i32) {
+    pub fn equip(&mut self, player_id: i32, item_id: i32, sub_loc: i32) {
         let character = match self.characters.get_mut(&player_id) {
             Some(character) => character,
             None => return,
@@ -28,7 +28,7 @@ impl Map {
             return;
         }
 
-        let result = character.equip(is_deep, item_id, sub_loc);
+        let result = character.equip(item_id, sub_loc);
 
         if result == EquipResult::Failed {
             return;

--- a/src/map/map/character/equip.rs
+++ b/src/map/map/character/equip.rs
@@ -9,41 +9,28 @@ use eolib::protocol::{
     r#pub::ItemType,
 };
 
-use crate::ITEM_DB;
+use crate::{
+    character::EquipResult,
+    deep::{PaperdollSwapServerPacket, ACTION_SWAP},
+    ITEM_DB,
+};
 
 use super::super::Map;
 
 impl Map {
-    pub async fn equip(&mut self, player_id: i32, item_id: i32, sub_loc: i32) {
+    pub fn equip(&mut self, player_id: i32, is_deep: bool, item_id: i32, sub_loc: i32) {
         let character = match self.characters.get_mut(&player_id) {
             Some(character) => character,
-            None => {
-                error!("Failed to get character");
-                return;
-            }
+            None => return,
         };
 
-        // TODO: move this check to player thread
-        {
-            let player = match character.player.as_ref() {
-                Some(player) => player,
-                None => return,
-            };
-
-            if player.is_trading().await {
-                return;
-            }
-        }
-
         if !character.items.iter().any(|i| i.id == item_id) {
-            warn!(
-                "{} attempted to equip item they do not have",
-                character.name
-            );
             return;
         }
 
-        if !character.equip(item_id, sub_loc) {
+        let result = character.equip(is_deep, item_id, sub_loc);
+
+        if result == EquipResult::Failed {
             return;
         }
 
@@ -59,20 +46,32 @@ impl Map {
         };
 
         if let Some(player) = character.player.as_ref() {
-            player.send(
-                PacketAction::Agree,
-                PacketFamily::Paperdoll,
-                &PaperdollAgreeServerPacket {
-                    change: change.clone(),
-                    item_id,
-                    remaining_amount: match character.items.iter().find(|i| i.id == item_id) {
-                        Some(item) => item.amount,
-                        None => 0,
+            if let EquipResult::Swapped(removed_item_id) = result {
+                player.send(
+                    PacketAction::Unrecognized(ACTION_SWAP),
+                    PacketFamily::Paperdoll,
+                    &PaperdollSwapServerPacket {
+                        change: change.clone(),
+                        item_id,
+                        remaining_amount: character.get_item_amount(item_id),
+                        removed_item_id,
+                        removed_item_amount: character.get_item_amount(removed_item_id),
+                        stats: character.get_character_stats_equipment_change(),
                     },
-                    sub_loc,
-                    stats: character.get_character_stats_equipment_change(),
-                },
-            );
+                );
+            } else {
+                player.send(
+                    PacketAction::Agree,
+                    PacketFamily::Paperdoll,
+                    &PaperdollAgreeServerPacket {
+                        change: change.clone(),
+                        item_id,
+                        remaining_amount: character.get_item_amount(item_id),
+                        sub_loc,
+                        stats: character.get_character_stats_equipment_change(),
+                    },
+                );
+            }
         }
 
         if character.hidden {

--- a/src/map/map/character/mod.rs
+++ b/src/map/map/character/mod.rs
@@ -1,5 +1,6 @@
 mod attack;
 mod cast_spell;
+mod close_captcha;
 mod drop_item;
 mod emote;
 mod enter;
@@ -12,6 +13,7 @@ mod leave;
 mod level_skill;
 mod level_stat;
 mod lose_item;
+mod open_captcha;
 mod open_door;
 mod party_request;
 mod remove_karma;

--- a/src/map/map/character/mod.rs
+++ b/src/map/map/character/mod.rs
@@ -31,4 +31,5 @@ mod stand;
 mod start_spell_chant;
 mod unequip;
 mod use_item;
+mod use_title_item;
 mod walk;

--- a/src/map/map/character/open_captcha.rs
+++ b/src/map/map/character/open_captcha.rs
@@ -1,0 +1,16 @@
+use super::super::Map;
+
+impl Map {
+    pub fn open_captcha(&mut self, player_id: i32) {
+        let character = match self.characters.get_mut(&player_id) {
+            Some(character) => character,
+            None => return,
+        };
+
+        if !character.is_deep {
+            return;
+        }
+
+        character.captcha_open = true;
+    }
+}

--- a/src/map/map/character/party_request.rs
+++ b/src/map/map/character/party_request.rs
@@ -29,7 +29,10 @@ impl Map {
             None => return,
         };
 
-        if !in_client_range(&character.coords, &target_character.coords) {
+        if target_character.hidden
+            || target_character.captcha_open
+            || !in_client_range(&character.coords, &target_character.coords)
+        {
             return;
         }
 

--- a/src/map/map/character/request_npcs.rs
+++ b/src/map/map/character/request_npcs.rs
@@ -1,9 +1,11 @@
 use eolib::protocol::net::{server::NpcAgreeServerPacket, PacketAction, PacketFamily};
 
+use crate::deep::{BossPingServerPacket, FAMILY_BOSS};
+
 use super::super::Map;
 
 impl Map {
-    pub fn request_npcs(&self, player_id: i32, npcs_indexes: Vec<i32>) {
+    pub fn request_npcs(&self, player_id: i32, npc_indexes: Vec<i32>) {
         let character = match self.characters.get(&player_id) {
             Some(character) => character,
             None => return,
@@ -18,7 +20,7 @@ impl Map {
                         .npcs
                         .iter()
                         .filter_map(|(index, npc)| {
-                            if npc.alive && npcs_indexes.contains(index) {
+                            if npc.alive && npc_indexes.contains(index) {
                                 Some(npc.to_map_info(index))
                             } else {
                                 None
@@ -27,6 +29,26 @@ impl Map {
                         .collect(),
                 },
             );
+
+            if character.is_deep {
+                for (npc_index, npc) in self
+                    .npcs
+                    .iter()
+                    .filter(|(index, npc)| npc.alive && npc.boss && npc_indexes.contains(index))
+                {
+                    player.send(
+                        PacketAction::Ping,
+                        PacketFamily::Unrecognized(FAMILY_BOSS),
+                        &BossPingServerPacket {
+                            npc_index: *npc_index,
+                            npc_id: npc.id,
+                            hp: npc.hp,
+                            hp_percentage: npc.get_hp_percentage(),
+                            killed: false,
+                        },
+                    );
+                }
+            }
         }
     }
 }

--- a/src/map/map/character/request_players_and_npcs.rs
+++ b/src/map/map/character/request_players_and_npcs.rs
@@ -3,6 +3,8 @@ use eolib::protocol::net::{
     PacketAction, PacketFamily,
 };
 
+use crate::deep::{BossPingServerPacket, FAMILY_BOSS};
+
 use super::super::Map;
 
 impl Map {
@@ -53,5 +55,25 @@ impl Map {
                 },
             },
         );
+
+        if character.is_deep {
+            for (npc_index, npc) in self
+                .npcs
+                .iter()
+                .filter(|(index, npc)| npc.alive && npc.boss && npc_indexes.contains(index))
+            {
+                player.send(
+                    PacketAction::Ping,
+                    PacketFamily::Unrecognized(FAMILY_BOSS),
+                    &BossPingServerPacket {
+                        npc_index: *npc_index,
+                        npc_id: npc.id,
+                        hp: npc.hp,
+                        hp_percentage: npc.get_hp_percentage(),
+                        killed: false,
+                    },
+                );
+            }
+        }
     }
 }

--- a/src/map/map/character/request_refresh.rs
+++ b/src/map/map/character/request_refresh.rs
@@ -3,7 +3,10 @@ use eolib::protocol::net::{
     PacketAction, PacketFamily,
 };
 
-use crate::utils::in_client_range;
+use crate::{
+    deep::{BossPingServerPacket, FAMILY_BOSS},
+    utils::in_client_range,
+};
 
 use super::super::Map;
 
@@ -62,5 +65,23 @@ impl Map {
                 },
             },
         );
+
+        if character.is_deep {
+            for (npc_index, npc) in self.npcs.iter().filter(|(_, npc)| {
+                npc.alive && npc.boss && in_client_range(&character.coords, &npc.coords)
+            }) {
+                player.send(
+                    PacketAction::Ping,
+                    PacketFamily::Unrecognized(FAMILY_BOSS),
+                    &BossPingServerPacket {
+                        npc_index: *npc_index,
+                        npc_id: npc.id,
+                        hp: npc.hp,
+                        hp_percentage: npc.get_hp_percentage(),
+                        killed: false,
+                    },
+                );
+            }
+        }
     }
 }

--- a/src/map/map/character/use_item.rs
+++ b/src/map/map/character/use_item.rs
@@ -320,10 +320,7 @@ impl Map {
 
                     for (is_deep, player) in self.characters.iter().filter_map(|(id, c)| {
                         if *id != player_id || in_client_range(&c.coords, &character_coords) {
-                            match &c.player {
-                                Some(player) => Some((c.is_deep, player)),
-                                None => None,
-                            }
+                            c.player.as_ref().map(|player| (c.is_deep, player))
                         } else {
                             None
                         }
@@ -381,10 +378,10 @@ impl Map {
                 return;
             }
 
-            if item.r#type == ItemType::Reserved5 || item.r#type == ItemType::Reserved7 {
-                if writer.add_char(item.spec1).is_err() {
-                    return;
-                }
+            if (item.r#type == ItemType::Reserved5 || item.r#type == ItemType::Reserved7)
+                && writer.add_char(item.spec1).is_err()
+            {
+                return;
             }
 
             player.send_buf(

--- a/src/map/map/character/use_title_item.rs
+++ b/src/map/map/character/use_title_item.rs
@@ -1,0 +1,59 @@
+use eolib::protocol::{
+    net::{server::ItemReplyServerPacket, Item, PacketAction, PacketFamily},
+    r#pub::ItemType,
+};
+
+use crate::{ITEM_DB, SETTINGS};
+
+use super::super::Map;
+
+impl Map {
+    pub fn use_title_item(&mut self, player_id: i32, item_id: i32, title: String) {
+        let character = match self.characters.get_mut(&player_id) {
+            Some(character) => character,
+            None => {
+                return;
+            }
+        };
+
+        if !character.items.iter().any(|item| item.id == item_id) {
+            return;
+        }
+
+        let item = match ITEM_DB.items.get(item_id as usize - 1) {
+            Some(item) => item,
+            None => {
+                return;
+            }
+        };
+
+        if item.r#type != ItemType::Reserved28 {
+            return;
+        }
+
+        character.title = Some(title);
+
+        if !SETTINGS.items.infinite_use_items.contains(&item_id) {
+            character.remove_item(item_id, 1);
+        }
+
+        if let Some(player) = character.player.as_ref() {
+            player.send(
+                PacketAction::Reply,
+                PacketFamily::Item,
+                &ItemReplyServerPacket {
+                    item_type: ItemType::Reserved28,
+                    used_item: Item {
+                        id: item_id,
+                        amount: match character.items.iter().find(|i| i.id == item_id) {
+                            Some(item) => item.amount,
+                            None => 0,
+                        },
+                    },
+                    weight: character.get_weight(),
+                    item_type_data: None,
+                },
+            );
+        }
+    }
+}

--- a/src/map/map/events/act_npcs.rs
+++ b/src/map/map/events/act_npcs.rs
@@ -179,6 +179,7 @@ impl Map {
                 };
                 let distance = get_distance(&npc.coords, &character.coords);
                 !character.hidden
+                    && !character.captcha_open
                     && distance <= SETTINGS.npcs.chase_distance
                     && opponent.bored_ticks < SETTINGS.npcs.bored_timer
             });
@@ -193,7 +194,9 @@ impl Map {
                 .iter()
                 .filter(|(_, character)| {
                     let distance = get_distance(&npc.coords, &character.coords);
-                    !character.hidden && distance <= SETTINGS.npcs.chase_distance
+                    !character.hidden
+                        && !character.captcha_open
+                        && distance <= SETTINGS.npcs.chase_distance
                 })
                 .min_by(|(_, a), (_, b)| {
                     let distance_a = get_distance(&npc.coords, &a.coords);
@@ -218,9 +221,9 @@ impl Map {
             .characters
             .iter()
             .filter(|(_, character)| {
-                adjacent_tiles
-                    .iter()
-                    .any(|coords| coords == &character.coords && !character.hidden)
+                adjacent_tiles.iter().any(|coords| {
+                    coords == &character.coords && !character.hidden && !character.captcha_open
+                })
             })
             .map(|(player_id, _)| *player_id)
             .collect::<Vec<_>>();

--- a/src/map/map/events/act_npcs.rs
+++ b/src/map/map/events/act_npcs.rs
@@ -181,7 +181,6 @@ impl Map {
                 !character.hidden
                     && !character.captcha_open
                     && distance <= SETTINGS.npcs.chase_distance
-                    && opponent.bored_ticks < SETTINGS.npcs.bored_timer
             });
 
             // get opponent with max damage dealt
@@ -231,10 +230,7 @@ impl Map {
         let adjacent_opponent = npc
             .opponents
             .iter()
-            .filter(|opponent| {
-                adjacent_player_ids.contains(&opponent.player_id)
-                    && opponent.bored_ticks < SETTINGS.npcs.bored_timer
-            })
+            .filter(|opponent| adjacent_player_ids.contains(&opponent.player_id))
             .max_by_key(|opponent| opponent.damage_dealt);
 
         if let Some(opponent) = adjacent_opponent {
@@ -456,6 +452,7 @@ impl Map {
         if act_rate == 0 || act_ticks == 0 || act_ticks < act_rate {
             (None, talk_update, None)
         } else {
+            self.drop_opponents(index);
             let attack_update = self.act_npc_attack(index, npc_id);
             let pos_update = if attack_update.is_some() {
                 None
@@ -464,6 +461,16 @@ impl Map {
             };
             (pos_update, talk_update, attack_update)
         }
+    }
+
+    fn drop_opponents(&mut self, index: i32) {
+        let npc = match self.npcs.get_mut(&index) {
+            Some(npc) => npc,
+            None => return,
+        };
+
+        npc.opponents
+            .retain(|o| o.bored_ticks < SETTINGS.npcs.bored_timer);
     }
 
     pub fn act_npcs(&mut self) {

--- a/src/map/map/events/spawn_npcs.rs
+++ b/src/map/map/events/spawn_npcs.rs
@@ -167,7 +167,7 @@ impl Map {
                     3 => Direction::Right,
                     _ => unreachable!(),
                 }
-            }
+            };
         }
     }
 }

--- a/src/map/map/quest/award_experience.rs
+++ b/src/map/map/quest/award_experience.rs
@@ -1,4 +1,7 @@
-use eolib::protocol::net::{server::RecoverReplyServerPacket, PacketAction, PacketFamily};
+use eolib::protocol::net::{
+    server::{ItemAcceptServerPacket, RecoverReplyServerPacket},
+    PacketAction, PacketFamily,
+};
 
 use super::super::Map;
 
@@ -38,6 +41,15 @@ impl Map {
                     None
                 },
             },
-        )
+        );
+
+        if leveled_up {
+            self.send_packet_near_player(
+                player_id,
+                PacketAction::Accept,
+                PacketFamily::Item,
+                &ItemAcceptServerPacket { player_id },
+            );
+        }
     }
 }

--- a/src/map/map/trade/request_trade.rs
+++ b/src/map/map/trade/request_trade.rs
@@ -12,34 +12,26 @@ impl Map {
 
         let character = match self.characters.get(&player_id) {
             Some(character) => character,
-            None => {
-                error!("Failed to get character");
-                return;
-            }
+            None => return,
         };
 
         let player = match character.player.as_ref() {
             Some(player) => player,
-            None => {
-                error!("Failed to get player");
-                return;
-            }
+            None => return,
         };
 
         let target = match self.characters.get(&target_player_id) {
             Some(character) => character,
-            None => {
-                error!("Failed to get target");
-                return;
-            }
+            None => return,
         };
+
+        if target.hidden || target.captcha_open {
+            return;
+        }
 
         let target_player = match target.player.as_ref() {
             Some(player) => player,
-            None => {
-                error!("Failed to get target player");
-                return;
-            }
+            None => return,
         };
 
         if in_client_range(&character.coords, &target.coords) {

--- a/src/map/map/utils/recover_npcs.rs
+++ b/src/map/map/utils/recover_npcs.rs
@@ -3,7 +3,7 @@ use super::super::Map;
 impl Map {
     pub async fn recover_npcs(&mut self) {
         for npc in self.npcs.values_mut() {
-            if npc.hp < npc.max_hp {
+            if npc.alive && npc.hp < npc.max_hp {
                 npc.hp += (npc.max_hp / 10) + 1;
                 if npc.hp > npc.max_hp {
                     npc.hp = npc.max_hp;

--- a/src/map/map/utils/spawn_npc.rs
+++ b/src/map/map/utils/spawn_npc.rs
@@ -38,6 +38,8 @@ impl Map {
                     alive: true,
                     hp: npc_data.hp,
                     max_hp: npc_data.hp,
+                    boss: npc_data.boss,
+                    child: npc_data.child,
                     ..Default::default()
                 },
             );

--- a/src/map/map_handle.rs
+++ b/src/map/map_handle.rs
@@ -185,9 +185,10 @@ impl MapHandle {
         rx.await.unwrap();
     }
 
-    pub fn equip(&self, player_id: i32, item_id: i32, sub_loc: i32) {
+    pub fn equip(&self, player_id: i32, is_deep: bool, item_id: i32, sub_loc: i32) {
         let _ = self.tx.send(Command::Equip {
             player_id,
+            is_deep,
             item_id,
             sub_loc,
         });

--- a/src/map/map_handle.rs
+++ b/src/map/map_handle.rs
@@ -98,6 +98,13 @@ impl MapHandle {
         let _ = self.tx.send(Command::CastSpell { player_id, target });
     }
 
+    pub fn close_captcha(&self, player_id: i32, experience: i32) {
+        let _ = self.tx.send(Command::CloseCaptcha {
+            player_id,
+            experience,
+        });
+    }
+
     pub fn craft_item(&self, player_id: i32, npc_index: i32, item_id: i32) {
         let _ = self.tx.send(Command::CraftItem {
             player_id,
@@ -386,6 +393,10 @@ impl MapHandle {
             player_id,
             board_id,
         });
+    }
+
+    pub fn open_captcha(&self, player_id: i32) {
+        let _ = self.tx.send(Command::OpenCaptcha { player_id });
     }
 
     pub fn open_chest(&self, player_id: i32, coords: Coords) {

--- a/src/map/map_handle.rs
+++ b/src/map/map_handle.rs
@@ -823,6 +823,14 @@ impl MapHandle {
         let _ = self.tx.send(Command::UseItem { player_id, item_id });
     }
 
+    pub fn use_title_item(&self, player_id: i32, item_id: i32, title: String) {
+        let _ = self.tx.send(Command::UseTitleItem {
+            player_id,
+            item_id,
+            title,
+        });
+    }
+
     pub fn view_board_post(&self, player_id: i32, board_id: i32, post_id: i32) {
         let _ = self.tx.send(Command::ViewBoardPost {
             player_id,

--- a/src/map/map_handle.rs
+++ b/src/map/map_handle.rs
@@ -185,10 +185,9 @@ impl MapHandle {
         rx.await.unwrap();
     }
 
-    pub fn equip(&self, player_id: i32, is_deep: bool, item_id: i32, sub_loc: i32) {
+    pub fn equip(&self, player_id: i32, item_id: i32, sub_loc: i32) {
         let _ = self.tx.send(Command::Equip {
             player_id,
-            is_deep,
             item_id,
             sub_loc,
         });

--- a/src/player/captcha.rs
+++ b/src/player/captcha.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, Default)]
+pub struct Captcha {
+    pub challenge: String,
+    pub reward: i32,
+    pub attempts: i32,
+}

--- a/src/player/command.rs
+++ b/src/player/command.rs
@@ -76,6 +76,9 @@ pub enum Command {
     SetTrading(bool),
     SetChestIndex(usize),
     SetSleepCost(i32),
+    ShowCaptcha {
+        experience: i32,
+    },
     Tick,
     UpdatePartyHP {
         hp_percentage: i32,

--- a/src/player/command.rs
+++ b/src/player/command.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use eolib::protocol::{
     net::{
         server::{GuildReply, WarpEffect},
-        PacketAction, PacketFamily,
+        PacketAction, PacketFamily, Version,
     },
     Coords,
 };
@@ -48,6 +48,9 @@ pub enum Command {
     },
     GetState {
         respond_to: oneshot::Sender<ClientState>,
+    },
+    GetVersion {
+        respond_to: oneshot::Sender<Version>,
     },
     IsTradeAccepted {
         respond_to: oneshot::Sender<bool>,

--- a/src/player/command.rs
+++ b/src/player/command.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use eolib::protocol::{
     net::{
         server::{GuildReply, WarpEffect},
-        PacketAction, PacketFamily, Version,
+        PacketAction, PacketFamily,
     },
     Coords,
 };
@@ -48,9 +48,6 @@ pub enum Command {
     },
     GetState {
         respond_to: oneshot::Sender<ClientState>,
-    },
-    GetVersion {
-        respond_to: oneshot::Sender<Version>,
     },
     IsTradeAccepted {
         respond_to: oneshot::Sender<bool>,

--- a/src/player/handle_packet.rs
+++ b/src/player/handle_packet.rs
@@ -4,7 +4,7 @@ use eolib::{
     protocol::net::{PacketAction, PacketFamily},
 };
 
-use crate::SETTINGS;
+use crate::{deep::FAMILY_CAPTCHA, SETTINGS};
 
 use super::{ClientState, Player};
 
@@ -21,7 +21,7 @@ impl Player {
 
         let family = PacketFamily::from(reader.get_byte().unwrap_or(0xfe));
         if let PacketFamily::Unrecognized(id) = family {
-            if id != 0xfe {
+            if id != 0xfe && id != FAMILY_CAPTCHA {
                 self.close("invalid packet family".to_string()).await;
                 return;
             }
@@ -94,6 +94,7 @@ impl Player {
             PacketFamily::Walk => self.handle_walk(reader),
             PacketFamily::Warp => self.handle_warp(action, reader).await,
             PacketFamily::Unrecognized(0xfe) => {} // ignored packet
+            PacketFamily::Unrecognized(FAMILY_CAPTCHA) => self.handle_captcha(action, reader).await,
             PacketFamily::Welcome => self.handle_welcome(action, reader).await,
             _ => {
                 error!("Unhandled packet {:?}_{:?}", action, family);

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -1,3 +1,5 @@
+mod captcha;
+pub use captcha::Captcha;
 mod client_state;
 pub use client_state::ClientState;
 mod command;

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -152,6 +152,9 @@ impl Player {
             Command::GetState { respond_to } => {
                 let _ = respond_to.send(self.state);
             }
+            Command::GetVersion { respond_to } => {
+                let _ = respond_to.send(self.version.clone());
+            }
             Command::IsTradeAccepted { respond_to } => {
                 let _ = respond_to.send(self.trade_accepted);
             }

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, collections::VecDeque};
 
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use eolib::protocol::net::{server::GuildReplyServerPacket, PacketAction, PacketFamily};
+use eolib::protocol::net::{server::GuildReplyServerPacket, PacketAction, PacketFamily, Version};
 use mysql_async::Pool;
 use tokio::{net::TcpStream, sync::mpsc::UnboundedReceiver};
 
@@ -38,6 +38,7 @@ pub struct Player {
     party_request: PartyRequest,
     ping_ticks: i32,
     guild_create_members: Vec<i32>,
+    version: Version,
 }
 
 mod account;
@@ -97,6 +98,7 @@ impl Player {
             party_request: PartyRequest::None,
             ping_ticks: 0,
             guild_create_members: Vec::new(),
+            version: Version::default(),
         }
     }
 

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -24,6 +24,7 @@ pub struct Player {
     pub state: ClientState,
     ip: String,
     pub connected_at: DateTime<Utc>,
+    pub closed: bool,
     login_attempts: i32,
     character: Option<Character>,
     session_id: Option<i32>,
@@ -39,6 +40,7 @@ pub struct Player {
     ping_ticks: i32,
     guild_create_members: Vec<i32>,
     version: Version,
+    email_code: Option<String>,
 }
 
 mod account;
@@ -54,6 +56,7 @@ mod get_welcome_request_data;
 mod handlers;
 #[macro_use]
 mod guild;
+mod generate_email_code;
 mod ping;
 mod quest_action;
 mod request_warp;
@@ -81,6 +84,7 @@ impl Player {
             queue: RefCell::new(VecDeque::new()),
             map: None,
             busy: false,
+            closed: false,
             account_id: 0,
             state: ClientState::Uninitialized,
             login_attempts: 0,
@@ -99,6 +103,7 @@ impl Player {
             ping_ticks: 0,
             guild_create_members: Vec::new(),
             version: Version::default(),
+            email_code: None,
         }
     }
 

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -40,7 +40,7 @@ pub struct Player {
     ping_ticks: i32,
     guild_create_members: Vec<i32>,
     version: Version,
-    email_code: Option<String>,
+    email_pin: Option<String>,
 }
 
 mod account;
@@ -56,7 +56,7 @@ mod get_welcome_request_data;
 mod handlers;
 #[macro_use]
 mod guild;
-mod generate_email_code;
+mod generate_email_pin;
 mod ping;
 mod quest_action;
 mod request_warp;
@@ -103,7 +103,7 @@ impl Player {
             ping_ticks: 0,
             guild_create_members: Vec::new(),
             version: Version::default(),
-            email_code: None,
+            email_pin: None,
         }
     }
 

--- a/src/player/player.rs
+++ b/src/player/player.rs
@@ -157,9 +157,6 @@ impl Player {
             Command::GetState { respond_to } => {
                 let _ = respond_to.send(self.state);
             }
-            Command::GetVersion { respond_to } => {
-                let _ = respond_to.send(self.version.clone());
-            }
             Command::IsTradeAccepted { respond_to } => {
                 let _ = respond_to.send(self.trade_accepted);
             }

--- a/src/player/player/close.rs
+++ b/src/player/player/close.rs
@@ -36,6 +36,9 @@ impl Player {
             )
             .await
             .unwrap();
+
+        self.closed = true;
+
         info!("player {} connection closed: {:?}", self.id, reason);
     }
 }

--- a/src/player/player/enter_game.rs
+++ b/src/player/player/enter_game.rs
@@ -1,16 +1,14 @@
-use eolib::{
-    protocol::net::{
-        server::{
-            WelcomeCode, WelcomeReplyServerPacket, WelcomeReplyServerPacketWelcomeCodeData,
-            WelcomeReplyServerPacketWelcomeCodeDataEnterGame,
-        },
-        PacketAction, PacketFamily,
+use eolib::protocol::net::{
+    server::{
+        WelcomeCode, WelcomeReplyServerPacket, WelcomeReplyServerPacketWelcomeCodeData,
+        WelcomeReplyServerPacketWelcomeCodeDataEnterGame,
     },
+    PacketAction, PacketFamily,
 };
 use std::{io::Cursor, path::Path};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 
-use crate::{errors::WrongSessionIdError, player::ClientState};
+use crate::{errors::WrongSessionIdError, player::ClientState, utils::is_deep};
 
 use super::Player;
 
@@ -60,6 +58,8 @@ impl Player {
         if let Some(relog_coords) = map.get_relog_coords().await {
             character.coords = relog_coords;
         }
+
+        character.is_deep = is_deep(&self.version);
 
         map.enter(Box::new(character), None).await;
 

--- a/src/player/player/generate_email_code.rs
+++ b/src/player/player/generate_email_code.rs
@@ -1,0 +1,12 @@
+use rand::Rng;
+
+use super::super::Player;
+
+impl Player {
+    pub fn generate_email_code(&mut self) -> String {
+        let mut rng = rand::thread_rng();
+        let pin: u32 = rng.gen_range(1000000..9999999);
+        self.email_code = Some(pin.to_string());
+        pin.to_string()
+    }
+}

--- a/src/player/player/generate_email_pin.rs
+++ b/src/player/player/generate_email_pin.rs
@@ -3,10 +3,10 @@ use rand::Rng;
 use super::super::Player;
 
 impl Player {
-    pub fn generate_email_code(&mut self) -> String {
+    pub fn generate_email_pin(&mut self) -> String {
         let mut rng = rand::thread_rng();
         let pin: u32 = rng.gen_range(1000000..9999999);
-        self.email_code = Some(pin.to_string());
+        self.email_pin = Some(pin.to_string());
         pin.to_string()
     }
 }

--- a/src/player/player/handlers/account.rs
+++ b/src/player/player/handlers/account.rs
@@ -41,9 +41,9 @@ impl Player {
             }
         };
 
-        if let Some(email_code) = &self.email_code {
+        if let Some(email_pin) = &self.email_pin {
             reader.set_chunked_reading_mode(true);
-            let code = match reader.get_string() {
+            let pin = match reader.get_string() {
                 Ok(code) => code,
                 Err(e) => {
                     self.close(format!("Failed to get email code: {}", e)).await;
@@ -51,7 +51,7 @@ impl Player {
                 }
             };
 
-            if code != *email_code {
+            if pin != *email_pin {
                 let _ = self
                     .bus
                     .send(
@@ -392,7 +392,7 @@ impl Player {
             }
         };
 
-        let code = self.generate_email_code();
+        let code = self.generate_email_pin();
 
         if let Err(e) = send_email(
             &accept.email_address,

--- a/src/player/player/handlers/admin_interact.rs
+++ b/src/player/player/handlers/admin_interact.rs
@@ -2,8 +2,13 @@ use eolib::{
     data::{EoReader, EoSerialize},
     protocol::net::{
         client::{AdminInteractReportClientPacket, AdminInteractTellClientPacket},
-        PacketAction,
+        PacketAction, PacketFamily,
     },
+};
+
+use crate::{
+    deep::{AdminInteractAddServerPacket, AdminInteractTakeClientPacket, DialogLine, LookupType},
+    DROP_DB, ITEM_DB, NPC_DB, SETTINGS,
 };
 
 use super::super::Player;
@@ -43,10 +48,158 @@ impl Player {
         });
     }
 
+    fn admin_interact_take(&mut self, reader: EoReader) {
+        if !SETTINGS.world.info_reveals_drops {
+            return;
+        }
+
+        let take = match AdminInteractTakeClientPacket::deserialize(&reader) {
+            Ok(take) => take,
+            Err(e) => {
+                error!("Error deserializing AdminInteractTakeClientPacket: {}", e);
+                return;
+            }
+        };
+
+        match take.lookup_type {
+            LookupType::Item => self.lookup_item(take.id),
+            LookupType::Npc => self.lookup_npc(take.id),
+            _ => {}
+        }
+    }
+
+    fn lookup_item(&mut self, id: i32) {
+        let map = match &self.map {
+            Some(map) => map.clone(),
+            None => return,
+        };
+
+        let mut lines = Vec::new();
+
+        for npc in DROP_DB.npcs.iter() {
+            if let Some(drop) = npc
+                .drops
+                .iter()
+                .find(|drop| drop.item_id == id && drop.min_amount > 0 && drop.max_amount > 0)
+            {
+                let npc_name = match NPC_DB.npcs.get(npc.npc_id as usize - 1) {
+                    Some(npc) => npc.name.to_owned(),
+                    None => continue,
+                };
+
+                lines.push(DialogLine {
+                    left: npc_name,
+                    right: format!("{:.2}%", drop.rate as f32 / 64_000. * 100.),
+                });
+            }
+        }
+
+        if !lines.is_empty() {
+            lines.insert(
+                0,
+                DialogLine {
+                    left: "Drops:".to_string(),
+                    right: String::default(),
+                },
+            );
+
+            lines.insert(
+                0,
+                DialogLine {
+                    left: ' '.to_string(),
+                    right: String::default(),
+                },
+            );
+
+            let player_id = self.id;
+
+            tokio::spawn(async move {
+                let player = match map.get_character(player_id).await {
+                    Some(character) => match &character.player {
+                        Some(player) => player.to_owned(),
+                        None => return,
+                    },
+                    None => return,
+                };
+
+                player.send(
+                    PacketAction::Add,
+                    PacketFamily::AdminInteract,
+                    &AdminInteractAddServerPacket { lines },
+                );
+            });
+        }
+    }
+
+    fn lookup_npc(&mut self, id: i32) {
+        let map = match &self.map {
+            Some(map) => map.clone(),
+            None => return,
+        };
+
+        let mut lines = Vec::new();
+
+        let npc = match DROP_DB.npcs.iter().find(|npc| npc.npc_id == id) {
+            Some(npc) => npc,
+            None => return,
+        };
+
+        for drop in npc.drops.iter() {
+            if drop.min_amount > 0 && drop.max_amount > 0 {
+                let item_name = match ITEM_DB.items.get(drop.item_id as usize - 1) {
+                    Some(item) => item.name.to_owned(),
+                    None => continue,
+                };
+
+                lines.push(DialogLine {
+                    left: item_name,
+                    right: format!("{:.2}%", drop.rate as f32 / 64_000. * 100.),
+                });
+            }
+        }
+
+        if !lines.is_empty() {
+            lines.insert(
+                0,
+                DialogLine {
+                    left: "Drops:".to_string(),
+                    right: String::default(),
+                },
+            );
+
+            lines.insert(
+                0,
+                DialogLine {
+                    left: ' '.to_string(),
+                    right: String::default(),
+                },
+            );
+
+            let player_id = self.id;
+
+            tokio::spawn(async move {
+                let player = match map.get_character(player_id).await {
+                    Some(character) => match &character.player {
+                        Some(player) => player.to_owned(),
+                        None => return,
+                    },
+                    None => return,
+                };
+
+                player.send(
+                    PacketAction::Add,
+                    PacketFamily::AdminInteract,
+                    &AdminInteractAddServerPacket { lines },
+                );
+            });
+        }
+    }
+
     pub fn handle_admin_interact(&mut self, action: PacketAction, reader: EoReader) {
         match action {
             PacketAction::Report => self.admin_interact_report(reader),
             PacketAction::Tell => self.admin_interact_tell(reader),
+            PacketAction::Take => self.admin_interact_take(reader),
             _ => error!("Unhandled packet AdminInteract_{:?}", action),
         }
     }

--- a/src/player/player/handlers/attack.rs
+++ b/src/player/player/handlers/attack.rs
@@ -21,6 +21,10 @@ impl Player {
     }
 
     pub fn handle_attack(&mut self, action: PacketAction, reader: EoReader) {
+        if self.captcha.is_some() {
+            return;
+        }
+
         match action {
             PacketAction::Use => self.attack_use(reader),
             _ => error!("Unhandled packet Attack_{:?}", action),

--- a/src/player/player/handlers/captcha.rs
+++ b/src/player/player/handlers/captcha.rs
@@ -1,0 +1,74 @@
+use eolib::{
+    data::{EoReader, EoSerialize},
+    protocol::net::PacketAction,
+};
+
+use crate::{
+    deep::{CaptchaReplyClientPacket, CaptchaRequestClientPacket},
+    utils::is_deep,
+};
+
+use super::super::Player;
+
+impl Player {
+    async fn captcha_reply(&mut self, reader: EoReader) {
+        if let Some(map) = &self.map {
+            let reply = match CaptchaReplyClientPacket::deserialize(&reader) {
+                Ok(reply) => reply,
+                Err(e) => {
+                    error!("Failed to deserialize CaptchaReplyClientPacket: {}", e);
+                    return;
+                }
+            };
+
+            let (attempts, captcha, reward) = match &self.captcha {
+                Some(captcha) => (
+                    captcha.attempts + 1,
+                    captcha.challenge.to_owned(),
+                    captcha.reward,
+                ),
+                None => return,
+            };
+
+            if attempts > 5 {
+                return;
+            }
+
+            if reply.captcha != captcha {
+                if let Some(captcha) = &mut self.captcha {
+                    captcha.attempts += 1;
+                }
+                return;
+            }
+
+            self.captcha = None;
+
+            map.close_captcha(self.id, reward);
+        }
+    }
+
+    async fn captcha_request(&mut self, reader: EoReader) {
+        if let Err(e) = CaptchaRequestClientPacket::deserialize(&reader) {
+            error!("Failed to deserialize CaptchaRequestClientPacket: {}", e);
+            return;
+        }
+
+        if self.captcha.is_none() {
+            return;
+        }
+
+        self.update_captcha().await;
+    }
+
+    pub async fn handle_captcha(&mut self, action: PacketAction, reader: EoReader) {
+        if !is_deep(&self.version) {
+            return;
+        }
+
+        match action {
+            PacketAction::Reply => self.captcha_reply(reader).await,
+            PacketAction::Request => self.captcha_request(reader).await,
+            _ => error!("Unhandled packet Captcha_{:?}", action),
+        }
+    }
+}

--- a/src/player/player/handlers/face.rs
+++ b/src/player/player/handlers/face.rs
@@ -21,6 +21,10 @@ impl Player {
     }
 
     pub fn handle_face(&mut self, action: PacketAction, reader: EoReader) {
+        if self.captcha.is_some() {
+            return;
+        }
+
         match action {
             PacketAction::Player => self.face_player(reader),
             _ => error!("Unhandled packet Face_{:?}", action),

--- a/src/player/player/handlers/handle_command.rs
+++ b/src/player/player/handlers/handle_command.rs
@@ -342,6 +342,9 @@ pub async fn handle_command(
                     }
                     "global" => world.toggle_global(character.name.to_owned()),
                     "remap" => world.reload_map(character.map_id),
+                    "captcha" => {
+                        world.show_captcha(args[0].to_owned(), args[1].parse::<i32>().unwrap())
+                    }
                     _ => {
                         send_error_message(
                             &player,

--- a/src/player/player/handlers/init.rs
+++ b/src/player/player/handlers/init.rs
@@ -144,6 +144,8 @@ impl Player {
             return;
         }
 
+        self.version = request.version;
+
         let sequence_start = generate_sequence_start();
         let sequence_bytes = get_init_sequence_bytes(sequence_start);
         self.bus.sequencer.set_start(sequence_start);

--- a/src/player/player/handlers/mod.rs
+++ b/src/player/player/handlers/mod.rs
@@ -5,6 +5,7 @@ mod bank;
 mod barber;
 mod board;
 mod book;
+mod captcha;
 mod chair;
 mod character;
 mod chest;

--- a/src/player/player/handlers/paperdoll.rs
+++ b/src/player/player/handlers/paperdoll.rs
@@ -8,8 +8,6 @@ use eolib::{
     },
 };
 
-use crate::utils::is_deep;
-
 use super::super::Player;
 
 impl Player {
@@ -27,7 +25,7 @@ impl Player {
                 }
             };
 
-            map.equip(self.id, is_deep(&self.version), add.item_id, add.sub_loc);
+            map.equip(self.id, add.item_id, add.sub_loc);
         }
     }
 

--- a/src/player/player/handlers/paperdoll.rs
+++ b/src/player/player/handlers/paperdoll.rs
@@ -8,10 +8,16 @@ use eolib::{
     },
 };
 
+use crate::utils::is_deep;
+
 use super::super::Player;
 
 impl Player {
     fn paperdoll_add(&mut self, reader: EoReader) {
+        if self.trading {
+            return;
+        }
+
         if let Some(map) = &self.map {
             let add = match PaperdollAddClientPacket::deserialize(&reader) {
                 Ok(add) => add,
@@ -21,11 +27,15 @@ impl Player {
                 }
             };
 
-            map.equip(self.id, add.item_id, add.sub_loc);
+            map.equip(self.id, is_deep(&self.version), add.item_id, add.sub_loc);
         }
     }
 
     fn paperdoll_remove(&mut self, reader: EoReader) {
+        if self.trading {
+            return;
+        }
+
         if let Some(map) = &self.map {
             let remove = match PaperdollRemoveClientPacket::deserialize(&reader) {
                 Ok(remove) => remove,

--- a/src/player/player/handlers/walk.rs
+++ b/src/player/player/handlers/walk.rs
@@ -7,6 +7,10 @@ use super::super::Player;
 
 impl Player {
     pub fn handle_walk(&mut self, reader: EoReader) {
+        if self.captcha.is_some() {
+            return;
+        }
+
         if let Some(map) = &self.map {
             let packet = match WalkPlayerClientPacket::deserialize(&reader) {
                 Ok(packet) => packet,

--- a/src/player/player/handlers/warp.rs
+++ b/src/player/player/handlers/warp.rs
@@ -127,6 +127,7 @@ impl Player {
             };
 
             map.enter(Box::new(character), warp_session.animation).await;
+
             let nearby_info = map.get_nearby_info(self.id).await;
             self.map = Some(map);
 

--- a/src/player/player/show_captcha.rs
+++ b/src/player/player/show_captcha.rs
@@ -1,0 +1,50 @@
+use eolib::protocol::net::{PacketAction, PacketFamily};
+use rand::Rng;
+
+use crate::{
+    deep::{CaptchaOpenServerPacket, FAMILY_CAPTCHA},
+    player::Captcha,
+    utils::is_deep,
+};
+
+use super::super::Player;
+
+impl Player {
+    pub async fn show_captcha(&mut self, experience: i32) {
+        if !is_deep(&self.version) {
+            return;
+        }
+
+        let captcha: String = {
+            let mut rng = rand::thread_rng();
+            (0..5)
+                .map(|_| {
+                    rng.gen_range(65..=90) as u8 as char // ASCII codes for upper case letters
+                })
+                .collect()
+        };
+
+        self.captcha = Some(Captcha {
+            challenge: captcha.to_owned(),
+            reward: experience,
+            attempts: 0,
+        });
+
+        if let Some(map) = &self.map {
+            map.open_captcha(self.id);
+        }
+
+        let _ = self
+            .bus
+            .send(
+                PacketAction::Open,
+                PacketFamily::Unrecognized(FAMILY_CAPTCHA),
+                CaptchaOpenServerPacket {
+                    id: 1,
+                    reward_exp: experience,
+                    captcha: Some(captcha),
+                },
+            )
+            .await;
+    }
+}

--- a/src/player/player/update_captcha.rs
+++ b/src/player/player/update_captcha.rs
@@ -1,0 +1,38 @@
+use eolib::protocol::net::{PacketAction, PacketFamily};
+use rand::Rng;
+
+use crate::deep::{CaptchaAgreeServerPacket, FAMILY_CAPTCHA};
+
+use super::super::Player;
+
+impl Player {
+    pub async fn update_captcha(&mut self) {
+        let captcha = match &mut self.captcha {
+            Some(captcha) => captcha,
+            None => return,
+        };
+
+        captcha.challenge = {
+            let mut rng = rand::thread_rng();
+            (0..5)
+                .map(|_| {
+                    rng.gen_range(65..=90) as u8 as char // ASCII codes for upper case letters
+                })
+                .collect()
+        };
+
+        captcha.attempts = 0;
+
+        let _ = self
+            .bus
+            .send(
+                PacketAction::Agree,
+                PacketFamily::Unrecognized(FAMILY_CAPTCHA),
+                CaptchaAgreeServerPacket {
+                    id: 1,
+                    captcha: captcha.challenge.clone(),
+                },
+            )
+            .await;
+    }
+}

--- a/src/player/player_handle.rs
+++ b/src/player/player_handle.rs
@@ -7,7 +7,7 @@ use eolib::{
     protocol::{
         net::{
             server::{GuildReply, WarpEffect},
-            PacketAction, PacketFamily,
+            PacketAction, PacketFamily, Version,
         },
         Coords,
     },
@@ -138,6 +138,15 @@ impl PlayerHandle {
         let _ = self.tx.send(Command::GetState { respond_to: tx });
         match rx.await {
             Ok(state) => Ok(state),
+            Err(_) => Err("Player disconnected".into()),
+        }
+    }
+
+    pub async fn get_version(&self) -> Result<Version, Box<dyn std::error::Error + Send + Sync>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.tx.send(Command::GetVersion { respond_to: tx });
+        match rx.await {
+            Ok(version) => Ok(version),
             Err(_) => Err("Player disconnected".into()),
         }
     }

--- a/src/player/player_handle.rs
+++ b/src/player/player_handle.rs
@@ -231,6 +231,10 @@ impl PlayerHandle {
         let _ = self.tx.send(Command::SetTrading(trading));
     }
 
+    pub fn show_captcha(&self, experience: i32) {
+        let _ = self.tx.send(Command::ShowCaptcha { experience });
+    }
+
     pub fn tick(&self) {
         let _ = self.tx.send(Command::Tick);
     }

--- a/src/player/player_handle.rs
+++ b/src/player/player_handle.rs
@@ -251,6 +251,10 @@ impl PlayerHandle {
 
 async fn run_player(mut player: Player) {
     loop {
+        if player.closed {
+            break;
+        }
+
         tokio::select! {
             result = player.bus.recv() => match result {
                 Some(Ok(packet)) => {

--- a/src/player/player_handle.rs
+++ b/src/player/player_handle.rs
@@ -7,7 +7,7 @@ use eolib::{
     protocol::{
         net::{
             server::{GuildReply, WarpEffect},
-            PacketAction, PacketFamily, Version,
+            PacketAction, PacketFamily,
         },
         Coords,
     },
@@ -138,15 +138,6 @@ impl PlayerHandle {
         let _ = self.tx.send(Command::GetState { respond_to: tx });
         match rx.await {
             Ok(state) => Ok(state),
-            Err(_) => Err("Player disconnected".into()),
-        }
-    }
-
-    pub async fn get_version(&self) -> Result<Version, Box<dyn std::error::Error + Send + Sync>> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self.tx.send(Command::GetVersion { respond_to: tx });
-        match rx.await {
-            Ok(version) => Ok(version),
             Err(_) => Err("Player disconnected".into()),
         }
     }

--- a/src/player/player_handle.rs
+++ b/src/player/player_handle.rs
@@ -258,7 +258,7 @@ async fn run_player(mut player: Player) {
         tokio::select! {
             result = player.bus.recv() => match result {
                 Some(Ok(packet)) => {
-                    trace!("Recv: {:?}", &packet[..4]);
+                    trace!("Recv: {:?}", &packet[4..]);
                     player.queue.get_mut().push_back(packet);
                 },
                 Some(Err(e)) => {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -82,6 +82,7 @@ pub struct World {
     pub drain_hp_damage: f32,
     pub drain_tp_damage: f32,
     pub warp_suck_rate: i32,
+    pub info_reveals_drops: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -40,6 +40,8 @@ pub struct NewCharacter {
 
 #[derive(Debug, Deserialize)]
 pub struct Character {
+    pub max_name_length: usize,
+    pub max_skin: i32,
     pub max_hair_color: i32,
     pub max_hair_style: i32,
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -198,6 +198,9 @@ pub struct Barber {
 pub struct Account {
     pub delay_time: i32,
     pub email_validation: bool,
+    pub recovery: bool,
+    pub recovery_show_email: bool,
+    pub recovery_mask_email: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -190,6 +190,7 @@ pub struct Jukebox {
 
 #[derive(Debug, Deserialize)]
 pub struct Barber {
+    pub base_cost: i32,
     pub cost_per_level: i32,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -41,6 +41,7 @@ pub struct NewCharacter {
 #[derive(Debug, Deserialize)]
 pub struct Character {
     pub max_name_length: usize,
+    pub max_title_length: usize,
     pub max_skin: i32,
     pub max_hair_color: i32,
     pub max_hair_style: i32,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -195,6 +195,12 @@ pub struct Barber {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Account {
+    pub delay_time: i32,
+    pub email_validation: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Guild {
     pub min_players: usize,
     pub create_cost: i32,
@@ -238,9 +244,20 @@ pub struct Items {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct Smtp {
+    pub from_name: String,
+    pub from_address: String,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct Settings {
     pub server: Server,
     pub database: Database,
+    pub account: Account,
     pub new_character: NewCharacter,
     pub jail: Jail,
     pub rescue: Rescue,
@@ -261,6 +278,7 @@ pub struct Settings {
     pub evacuate: Evacuate,
     pub items: Items,
     pub bard: Bard,
+    pub smtp: Smtp,
 }
 
 impl Settings {

--- a/src/sql/get_account_email.sql
+++ b/src/sql/get_account_email.sql
@@ -1,0 +1,3 @@
+SELECT `id`, `email`
+FROM `Account`
+WHERE `name` = :name;

--- a/src/utils/is_deep.rs
+++ b/src/utils/is_deep.rs
@@ -1,0 +1,5 @@
+use eolib::protocol::net::Version;
+
+pub fn is_deep(version: &Version) -> bool {
+    version.minor > 0
+}

--- a/src/utils/mask_email.rs
+++ b/src/utils/mask_email.rs
@@ -1,0 +1,13 @@
+pub fn mask_email(email: &str) -> String {
+    let mut masked = String::with_capacity(email.len());
+    let position_of_at = email.chars().position(|c| c == '@').unwrap();
+    for (i, c) in email.chars().enumerate() {
+        if i == 0 || i >= position_of_at - 1 {
+            masked.push(c);
+        } else {
+            masked.push('*');
+        }
+    }
+
+    masked
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,6 +14,8 @@ mod get_board_tile_spec;
 pub use get_board_tile_spec::get_board_tile_spec;
 mod get_next_coords;
 pub use get_next_coords::get_next_coords;
+mod is_deep;
+pub use is_deep::is_deep;
 mod load_class_file;
 pub use load_class_file::load_class_file;
 mod load_drop_file;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -44,3 +44,5 @@ mod validate_character_name;
 pub use validate_character_name::validate_character_name;
 mod send_email;
 pub use send_email::send_email;
+mod mask_email;
+pub use mask_email::mask_email;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -42,3 +42,5 @@ mod pad_string;
 pub use pad_string::pad_string;
 mod validate_character_name;
 pub use validate_character_name::validate_character_name;
+mod send_email;
+pub use send_email::send_email;

--- a/src/utils/send_email.rs
+++ b/src/utils/send_email.rs
@@ -1,0 +1,28 @@
+use mail_builder::MessageBuilder;
+use mail_send::SmtpClientBuilder;
+
+use crate::SETTINGS;
+
+pub async fn send_email(to: &str, to_name: &str, subject: &str, body: &str) -> anyhow::Result<()> {
+    let message = MessageBuilder::new()
+        .from((
+            SETTINGS.smtp.from_name.to_owned(),
+            SETTINGS.smtp.from_address.to_owned(),
+        ))
+        .to((to_name, to))
+        .subject(subject)
+        .text_body(body);
+
+    SmtpClientBuilder::new(SETTINGS.smtp.host.to_owned(), SETTINGS.smtp.port)
+        .implicit_tls(false)
+        .credentials((
+            SETTINGS.smtp.username.to_owned(),
+            SETTINGS.smtp.password.to_owned(),
+        ))
+        .connect()
+        .await?
+        .send(message)
+        .await?;
+
+    Ok(())
+}

--- a/src/world/command.rs
+++ b/src/world/command.rs
@@ -186,6 +186,10 @@ pub enum Command {
         to: String,
         message: String,
     },
+    ShowCaptcha {
+        victim_name: String,
+        experience: i32,
+    },
     Shutdown {
         respond_to: oneshot::Sender<()>,
     },

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -303,6 +303,11 @@ impl World {
                 message,
             } => self.send_private_message(player_id, &to, &message).await,
 
+            Command::ShowCaptcha {
+                victim_name,
+                experience,
+            } => self.show_captcha(victim_name, experience),
+
             Command::Shutdown { respond_to } => self.shutdown(respond_to).await,
 
             Command::Tick => {

--- a/src/world/world/admin/mod.rs
+++ b/src/world/world/admin/mod.rs
@@ -9,5 +9,6 @@ mod report_player;
 mod request_player_info;
 mod request_player_inventory;
 mod send_admin_message;
+mod show_captcha;
 mod toggle_global;
 mod unfreeze_player;

--- a/src/world/world/admin/show_captcha.rs
+++ b/src/world/world/admin/show_captcha.rs
@@ -1,0 +1,17 @@
+use super::super::World;
+
+impl World {
+    pub fn show_captcha(&mut self, victim_name: String, experience: i32) {
+        let player_id = match self.characters.get(&victim_name) {
+            Some(player_id) => player_id,
+            None => return,
+        };
+
+        let player = match self.players.get(player_id) {
+            Some(player) => player,
+            None => return,
+        };
+
+        player.show_captcha(experience);
+    }
+}

--- a/src/world/world/reload_map.rs
+++ b/src/world/world/reload_map.rs
@@ -24,7 +24,7 @@ impl World {
             None => return,
         };
 
-        let raw_path = format!("maps/{:0>5}.emf", map_id);
+        let raw_path = format!("data/maps/{:0>5}.emf", map_id);
         let path = Path::new(&raw_path);
 
         if !Path::exists(path) {

--- a/src/world/world_handle.rs
+++ b/src/world/world_handle.rs
@@ -369,6 +369,13 @@ impl WorldHandle {
         });
     }
 
+    pub fn show_captcha(&self, victim_name: String, experience: i32) {
+        let _ = self.tx.send(Command::ShowCaptcha {
+            victim_name,
+            experience,
+        });
+    }
+
     pub async fn shutdown(&self) {
         let (tx, rx) = oneshot::channel();
         let _ = self.tx.send(Command::Shutdown { respond_to: tx });


### PR DESCRIPTION
This implements most features of the deep client Vult-r released

- Email validation
- Account recovery
- Account/Login config
- Boss sync
- Barber pricing
- Equipment swapping
- #item and #npc commands show drops (configurable)
- $captcha command (basically useless to combat botters though)
- New items: title cert, skin change, spell book

Also some bug fixes:

- Aggressive NPCs would get stuck if they had an opponent do nothing for 30 seconds
- Leveling up from a quest will now show to nearby players
- Probably more I don't remember