### PR TITLE
Fix: Short packets panic over TCP

### DIFF
--- a/src/player/packet_bus.rs
+++ b/src/player/packet_bus.rs
@@ -120,7 +120,10 @@ impl PacketBus {
             Socket::Web(socket) => match socket.next().await {
                 Some(Ok(Message::Binary(buf))) => {
                     if buf.len() < 4 {
-                        return None;
+                        return Some(Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("Received packet is too short: {}", buf.len()),
+                        )));
                     }
 
                     let mut data_buf = buf[2..].to_vec();
@@ -172,6 +175,16 @@ impl PacketBus {
                             match read.await {
                                 Some(Ok(buf)) => {
                                     let mut data_buf = buf;
+                                    if data_buf.len() < 3 {
+                                        return Some(Err(std::io::Error::new(
+                                            std::io::ErrorKind::InvalidData,
+                                            format!(
+                                                "Received packet is too short: {}",
+                                                data_buf.len()
+                                            ),
+                                        )));
+                                    }
+
                                     if self.client_enryption_multiple != 0 {
                                         decrypt_packet(
                                             &mut data_buf,

--- a/src/player/player_handle.rs
+++ b/src/player/player_handle.rs
@@ -288,7 +288,7 @@ async fn run_player(mut player: Player) {
                             break;
                         },
                         _ => {
-                            player.close(format!("Due to unknown error: {:?}", e)).await;
+                            player.close(format!("{}", e)).await;
                             break;
                         }
                     }


### PR DESCRIPTION
This pull request improves error handling and reporting for short or invalid packets received over the network, and refines error messages when closing a player connection. The main changes are:

**Error Handling and Reporting:**

* In `PacketBus`, when a binary message is received that is too short (less than 4 bytes), the code now returns a detailed `InvalidData` error instead of silently returning `None`. This makes it easier to diagnose protocol issues.
* Similarly, when reading from the packet stream, if the buffer is too short (less than 3 bytes), a descriptive `InvalidData` error is returned, improving debugging and robustness.

**Player Error Messaging:**

* In `run_player` (in `player_handle.rs`), when an unknown error occurs, the error message logged when closing the connection now only includes the error itself, rather than a prefixed message. This results in clearer and more direct error reporting.